### PR TITLE
feat: add global exception handling filter with Prisma error support

### DIFF
--- a/backend/src/common/filters/all-exceptions.filter.ts
+++ b/backend/src/common/filters/all-exceptions.filter.ts
@@ -1,0 +1,62 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+  catch(exception: any, host: ArgumentsHost): void {
+    const { httpAdapter } = this.httpAdapterHost;
+    const ctx = host.switchToHttp();
+
+    let httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = 'Internal server error';
+
+    if (exception instanceof HttpException) {
+      httpStatus = exception.getStatus();
+      const response = exception.getResponse();
+      message = (response as any).message || exception.message;
+    } else if (
+      exception &&
+      typeof exception === 'object' &&
+      (exception.constructor.name === 'PrismaClientKnownRequestError' ||
+        exception.name === 'PrismaClientKnownRequestError')
+    ) {
+      // Handle Prisma errors
+      switch (exception.code) {
+        case 'P2002':
+          httpStatus = HttpStatus.CONFLICT;
+          message = `Unique constraint failed on the fields: ${(exception.meta?.target as string[])?.join(', ')}`;
+          break;
+        case 'P2003':
+          httpStatus = HttpStatus.BAD_REQUEST;
+          message = 'Foreign key constraint failed';
+          break;
+        case 'P2025':
+          httpStatus = HttpStatus.NOT_FOUND;
+          message = 'Record not found';
+          break;
+        default:
+          httpStatus = HttpStatus.BAD_REQUEST;
+          message = `Prisma error: ${exception.message}`;
+      }
+    } else if (exception instanceof Error) {
+      message = exception.message;
+    }
+
+    const responseBody = {
+      statusCode: httpStatus,
+      message,
+      timestamp: new Date().toISOString(),
+      path: httpAdapter.getRequestUrl(ctx.getRequest()),
+    };
+
+    httpAdapter.reply(ctx.getResponse(), responseBody, httpStatus);
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,10 +1,14 @@
 import 'dotenv/config';
-import { NestFactory } from '@nestjs/core';
+import { NestFactory, HttpAdapterHost } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const httpAdapterHost = app.get(HttpAdapterHost);
+  app.useGlobalFilters(new AllExceptionsFilter(httpAdapterHost));
 
   const config = new DocumentBuilder()
     .setTitle('Stellar-Guilds')


### PR DESCRIPTION
- Title : feat: implement global exception handling filter
- Description :
Standardizes the API error responses across the application by implementing a global exception filter.

Key Changes :

- Created all-exceptions.filter.ts to catch all unhandled exceptions.
- Standardized JSON response format: { statusCode, message, timestamp, path } .
- Added specific handling for Prisma errors (Unique constraints, Foreign keys, and Record not found) using robust type-checking to avoid build-time issues.
- Registered the filter globally in main.ts .
Supported Prisma Codes :

- P2002 : Maps to 409 Conflict .
- P2003 : Maps to 400 Bad Request .
- P2025 : Maps to 404 Not Found .
Verification :

- Verified that standard HttpException (e.g., 404, 401) returns the correct format.
- Verified that database errors are caught and masked into user-friendly messages.
- Guidelines : Closes #94 