### PR TITLE
feat: build robust pagination utility for prisma

### DIFF
--- a/backend/src/common/utils/__tests__/pagination.util.spec.ts
+++ b/backend/src/common/utils/__tests__/pagination.util.spec.ts
@@ -1,0 +1,55 @@
+import { PaginationUtil } from "../pagination.util";
+
+describe("PaginationUtil", () => {
+  describe("getPagination", () => {
+    it("should return correct skip and take", () => {
+      const result = PaginationUtil.getPagination({ page: 2, limit: 10 });
+
+      expect(result.skip).toBe(10);
+      expect(result.take).toBe(10);
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(10);
+    });
+
+    it("should fallback to defaults", () => {
+      const result = PaginationUtil.getPagination({});
+
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(10);
+    });
+
+    it("should not exceed max limit", () => {
+      const result = PaginationUtil.getPagination({ limit: 500 });
+
+      expect(result.limit).toBe(100);
+    });
+  });
+
+  describe("buildMeta", () => {
+    it("should calculate metadata correctly", () => {
+      const meta = PaginationUtil.buildMeta(100, 2, 10);
+
+      expect(meta.total).toBe(100);
+      expect(meta.totalPages).toBe(10);
+      expect(meta.hasNextPage).toBe(true);
+      expect(meta.hasPreviousPage).toBe(true);
+    });
+
+    it("should detect last page", () => {
+      const meta = PaginationUtil.buildMeta(20, 2, 10);
+
+      expect(meta.hasNextPage).toBe(false);
+    });
+  });
+
+  describe("buildResult", () => {
+    it("should return data with meta", () => {
+      const data = [{ id: 1 }, { id: 2 }];
+
+      const result = PaginationUtil.buildResult(data, 20, 1, 10);
+
+      expect(result.data).toEqual(data);
+      expect(result.meta.total).toBe(20);
+    });
+  });
+});

--- a/backend/src/common/utils/pagination.types.ts
+++ b/backend/src/common/utils/pagination.types.ts
@@ -1,0 +1,18 @@
+export interface PaginationQuery {
+  page?: number;
+  limit?: number;
+}
+
+export interface PaginationMeta {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  meta: PaginationMeta;
+}

--- a/backend/src/common/utils/pagination.util.ts
+++ b/backend/src/common/utils/pagination.util.ts
@@ -1,0 +1,59 @@
+import {
+  PaginationQuery,
+  PaginationMeta,
+  PaginatedResult,
+} from "./pagination.types";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+export class PaginationUtil {
+  /**
+   * Converts page/limit into Prisma skip/take
+   */
+  static getPagination(query: PaginationQuery) {
+    const page = Math.max(query.page || DEFAULT_PAGE, 1);
+    const limit = Math.min(query.limit || DEFAULT_LIMIT, MAX_LIMIT);
+
+    const skip = (page - 1) * limit;
+    const take = limit;
+
+    return { skip, take, page, limit };
+  }
+
+  /**
+   * Builds pagination metadata
+   */
+  static buildMeta(
+    total: number,
+    page: number,
+    limit: number
+  ): PaginationMeta {
+    const totalPages = Math.ceil(total / limit);
+
+    return {
+      total,
+      page,
+      limit,
+      totalPages,
+      hasNextPage: page < totalPages,
+      hasPreviousPage: page > 1,
+    };
+  }
+
+  /**
+   * Wraps Prisma result into a paginated response
+   */
+  static buildResult<T>(
+    data: T[],
+    total: number,
+    page: number,
+    limit: number
+  ): PaginatedResult<T> {
+    return {
+      data,
+      meta: this.buildMeta(total, page, limit),
+    };
+  }
+}


### PR DESCRIPTION
- add generic pagination utility with skip/take support
- implement metadata builder (total, pages, navigation flags)
- add reusable paginated response wrapper
- include comprehensive unit tests (>95% coverage)

Closes #128 