### PR TITLE
feat: add join_guild function with auth enforcement

### DIFF
--- a/contract/src/bounty/mod.rs
+++ b/contract/src/bounty/mod.rs
@@ -1,4 +1,4 @@
-﻿/// Bounty Escrow Module
+/// Bounty Escrow Module
 ///
 /// This module handles bounty creation, funding, claiming, and escrow management
 /// for the Stellar Guilds platform.
@@ -18,7 +18,6 @@
 /// | Release escrow      | `(bounty, released)`     | `EscrowReleasedEvent`    |
 /// | Cancel bounty       | `(bounty, cancelled)`    | `BountyCancelledEvent`   |
 /// | Expire bounty       | `(bounty, expired)`      | `BountyExpiredEvent`     |
-
 pub mod escrow;
 pub mod storage;
 pub mod types;
@@ -33,8 +32,8 @@ use crate::dispute::storage as dispute_storage;
 use crate::dispute::types::DisputeReference;
 use crate::events::emit::emit_event;
 use crate::events::topics::{
-    ACT_APPROVED, ACT_CANCELLED, ACT_CLAIMED, ACT_CREATED, ACT_EXPIRED, ACT_FUNDED,
-    ACT_RELEASED, ACT_SUBMITTED, MOD_BOUNTY,
+    ACT_APPROVED, ACT_CANCELLED, ACT_CLAIMED, ACT_CREATED, ACT_EXPIRED, ACT_FUNDED, ACT_RELEASED,
+    ACT_SUBMITTED, MOD_BOUNTY,
 };
 use crate::guild::membership::has_permission;
 use crate::guild::types::Role;
@@ -136,7 +135,12 @@ pub fn fund_bounty(env: &Env, bounty_id: u64, funder: Address, amount: i128) -> 
     if now > bounty.expires_at {
         bounty.status = BountyStatus::Expired;
         store_bounty(env, &bounty);
-        emit_event(env, MOD_BOUNTY, ACT_EXPIRED, BountyExpiredEvent { bounty_id });
+        emit_event(
+            env,
+            MOD_BOUNTY,
+            ACT_EXPIRED,
+            BountyExpiredEvent { bounty_id },
+        );
         panic!("Bounty has expired");
     }
 
@@ -185,7 +189,12 @@ pub fn claim_bounty(env: &Env, bounty_id: u64, claimer: Address) -> bool {
     if now > bounty.expires_at {
         bounty.status = BountyStatus::Expired;
         store_bounty(env, &bounty);
-        emit_event(env, MOD_BOUNTY, ACT_EXPIRED, BountyExpiredEvent { bounty_id });
+        emit_event(
+            env,
+            MOD_BOUNTY,
+            ACT_EXPIRED,
+            BountyExpiredEvent { bounty_id },
+        );
         panic!("Bounty has expired");
     }
 
@@ -435,7 +444,12 @@ pub fn expire_bounty(env: &Env, bounty_id: u64) -> bool {
     bounty.status = BountyStatus::Expired;
     store_bounty(env, &bounty);
 
-    emit_event(env, MOD_BOUNTY, ACT_EXPIRED, BountyExpiredEvent { bounty_id });
+    emit_event(
+        env,
+        MOD_BOUNTY,
+        ACT_EXPIRED,
+        BountyExpiredEvent { bounty_id },
+    );
 
     true
 }

--- a/contract/src/bounty/tests.rs
+++ b/contract/src/bounty/tests.rs
@@ -1501,8 +1501,8 @@ fn test_approve_bounty_not_funded_fails() {
 
 #[test]
 fn test_bounty_serialization() {
-    use soroban_sdk::{IntoVal, TryFromVal, Val};
     use crate::bounty::types::Bounty;
+    use soroban_sdk::{IntoVal, TryFromVal, Val};
 
     let env = Env::default();
     let bounty = Bounty {
@@ -1520,10 +1520,10 @@ fn test_bounty_serialization() {
         created_at: 1000,
         expires_at: 2000,
     };
-    
+
     let val: Val = bounty.clone().into_val(&env);
     let deserialized: Bounty = Bounty::try_from_val(&env, &val).unwrap();
-    
+
     assert_eq!(bounty.id, deserialized.id);
     assert_eq!(bounty.status, deserialized.status);
     assert_eq!(bounty.reward_amount, deserialized.reward_amount);
@@ -1531,8 +1531,8 @@ fn test_bounty_serialization() {
 
 #[test]
 fn test_escrow_state_serialization() {
-    use soroban_sdk::{IntoVal, TryFromVal, Val};
     use crate::bounty::types::EscrowLockedState;
+    use soroban_sdk::{IntoVal, TryFromVal, Val};
 
     let env = Env::default();
     let state = EscrowLockedState {
@@ -1541,9 +1541,9 @@ fn test_escrow_state_serialization() {
         token: Address::generate(&env),
         is_locked: true,
     };
-    
+
     let val: Val = state.clone().into_val(&env);
     let deserialized: EscrowLockedState = EscrowLockedState::try_from_val(&env, &val).unwrap();
-    
+
     assert_eq!(state, deserialized);
 }

--- a/contract/src/events/emit.rs
+++ b/contract/src/events/emit.rs
@@ -1,4 +1,4 @@
-﻿/// Central event emission helper for the Stellar Guilds contract.
+/// Central event emission helper for the Stellar Guilds contract.
 ///
 /// All modules **must** emit events exclusively through `emit_event()`.
 /// Direct calls to `env.events().publish()` are forbidden outside this file
@@ -27,7 +27,6 @@
 /// # Size budget
 /// Soroban charges per-byte for event data. Keep payload structs lean; use
 /// IDs to reference large blobs stored elsewhere rather than inlining them.
-
 use crate::events::types::{EventEnvelope, EVENT_SCHEMA_VERSION, EVENT_SEQUENCE_KEY};
 use soroban_sdk::{Env, IntoVal, Symbol, Val};
 
@@ -86,7 +85,10 @@ where
     // Publish envelope on the meta-topic so indexers can track all events
     // without needing to know every module+action pair in advance.
     env.events().publish(
-        (Symbol::new(env, "stellar_guilds"), Symbol::new(env, "event")),
+        (
+            Symbol::new(env, "stellar_guilds"),
+            Symbol::new(env, "event"),
+        ),
         envelope,
     );
 

--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -1,4 +1,4 @@
-﻿/// Centralized event logging system for Stellar Guilds.
+/// Centralized event logging system for Stellar Guilds.
 ///
 /// # Problem solved
 /// Prior to this module, each sub-module emitted events independently with
@@ -53,7 +53,6 @@
 /// 4. Replace every `env.events().publish(...)` call in the module with
 ///    `emit_event(env, MOD_<MODULE>, ACT_<ACTION>, payload)`.
 /// 5. Document the new events in the module's top-level doc comment.
-
 pub mod emit;
 pub mod topics;
 pub mod types;

--- a/contract/src/events/topics.rs
+++ b/contract/src/events/topics.rs
@@ -1,4 +1,4 @@
-﻿/// Standardized event topic constants for all Stellar Guilds contract modules.
+/// Standardized event topic constants for all Stellar Guilds contract modules.
 ///
 /// Topics are two-element tuples of `(module, action)` Symbols that Stellar's
 /// event system uses for efficient filtering. All module code must use the
@@ -22,63 +22,64 @@
 
 // =========== Module identifiers ===========
 
-pub const MOD_GUILD: &str        = "guild";
-pub const MOD_BOUNTY: &str       = "bounty";
-pub const MOD_PAYMENT: &str      = "payment";
-pub const MOD_TREASURY: &str     = "treasury";
-pub const MOD_MILESTONE: &str    = "milestone";
-pub const MOD_GOVERNANCE: &str   = "governance";
-pub const MOD_REPUTATION: &str   = "reputation";
-pub const MOD_DISPUTE: &str      = "dispute";
+pub const MOD_GUILD: &str = "guild";
+pub const MOD_BOUNTY: &str = "bounty";
+pub const MOD_PAYMENT: &str = "payment";
+pub const MOD_TREASURY: &str = "treasury";
+pub const MOD_MILESTONE: &str = "milestone";
+pub const MOD_GOVERNANCE: &str = "governance";
+pub const MOD_REPUTATION: &str = "reputation";
+pub const MOD_DISPUTE: &str = "dispute";
 pub const MOD_SUBSCRIPTION: &str = "subscription";
-pub const MOD_MULTISIG: &str     = "multisig";
-pub const MOD_ALLOWANCE: &str    = "allowance";
-pub const MOD_EMERGENCY: &str    = "emergency";
-pub const MOD_UPGRADE: &str      = "upgrade";
-pub const MOD_PROXY: &str        = "proxy";
+pub const MOD_MULTISIG: &str = "multisig";
+pub const MOD_ALLOWANCE: &str = "allowance";
+pub const MOD_EMERGENCY: &str = "emergency";
+pub const MOD_UPGRADE: &str = "upgrade";
+pub const MOD_PROXY: &str = "proxy";
 
 // =========== Shared action identifiers (used across multiple modules) ===========
 
-pub const ACT_CREATED: &str    = "created";
-pub const ACT_UPDATED: &str    = "updated";
-pub const ACT_CANCELLED: &str  = "cancelled";
-pub const ACT_EXECUTED: &str   = "executed";
-pub const ACT_APPROVED: &str   = "approved";
-pub const ACT_REJECTED: &str   = "rejected";
-pub const ACT_RELEASED: &str   = "released";
-pub const ACT_EXPIRED: &str    = "expired";
-pub const ACT_PAUSED: &str     = "paused";
-pub const ACT_RESUMED: &str    = "resumed";
-pub const ACT_FUNDED: &str     = "funded";
-pub const ACT_FAILED: &str     = "failed";
+pub const ACT_CREATED: &str = "created";
+pub const ACT_UPDATED: &str = "updated";
+pub const ACT_CANCELLED: &str = "cancelled";
+pub const ACT_EXECUTED: &str = "executed";
+pub const ACT_APPROVED: &str = "approved";
+pub const ACT_REJECTED: &str = "rejected";
+pub const ACT_RELEASED: &str = "released";
+pub const ACT_EXPIRED: &str = "expired";
+pub const ACT_PAUSED: &str = "paused";
+pub const ACT_RESUMED: &str = "resumed";
+pub const ACT_FUNDED: &str = "funded";
+pub const ACT_FAILED: &str = "failed";
 
 // =========== Guild-specific actions ===========
 
-pub const ACT_MEMBER_ADDED: &str   = "member_added";
+pub const ACT_MEMBER_ADDED: &str = "member_added";
 pub const ACT_MEMBER_REMOVED: &str = "member_removed";
-pub const ACT_ROLE_UPDATED: &str   = "role_updated";
+pub const ACT_ROLE_UPDATED: &str = "role_updated";
+pub const ACT_JOINED: &str = "joined";
 
 // =========== Bounty-specific actions ===========
 
-pub const ACT_CLAIMED: &str    = "claimed";
-pub const ACT_SUBMITTED: &str  = "submitted";
+pub const ACT_CLAIMED: &str = "claimed";
+pub const ACT_SUBMITTED: &str = "submitted";
 
 // =========== Payment-specific actions ===========
 
 pub const ACT_RECIPIENT_ADDED: &str = "recipient_added";
-pub const ACT_DISTRIBUTED: &str     = "distributed";
+pub const ACT_DISTRIBUTED: &str = "distributed";
 
 // =========== Governance-specific actions ===========
 
-pub const ACT_VOTED: &str      = "voted";
-pub const ACT_DELEGATED: &str  = "delegated";
-pub const ACT_FINALIZED: &str  = "finalized";
-pub const ACT_PROPOSED: &str   = "proposed";
+pub const ACT_VOTED: &str = "voted";
+pub const ACT_DELEGATED: &str = "delegated";
+pub const ACT_FINALIZED: &str = "finalized";
+pub const ACT_PROPOSED: &str = "proposed";
 
 // =========== Milestone-specific actions ===========
 
-pub const ACT_STARTED: &str    = "started";
-pub const ACT_COMPLETED: &str  = "completed";
+pub const ACT_STARTED: &str = "started";
+pub const ACT_COMPLETED: &str = "completed";
 
 // =========== Reputation-specific actions ===========
 
@@ -87,33 +88,33 @@ pub const ACT_BADGE_EARNED: &str = "badge_earned";
 
 // =========== Dispute-specific actions ===========
 
-pub const ACT_EVIDENCE: &str   = "evidence";
-pub const ACT_VOTE_CAST: &str  = "vote_cast";
-pub const ACT_RESOLVED: &str   = "resolved";
+pub const ACT_EVIDENCE: &str = "evidence";
+pub const ACT_VOTE_CAST: &str = "vote_cast";
+pub const ACT_RESOLVED: &str = "resolved";
 
 // =========== Subscription-specific actions ===========
 
-pub const ACT_SUBSCRIBED: &str      = "subscribed";
-pub const ACT_PLAN_CREATED: &str    = "plan_created";
-pub const ACT_TIER_CHANGED: &str    = "tier_changed";
+pub const ACT_SUBSCRIBED: &str = "subscribed";
+pub const ACT_PLAN_CREATED: &str = "plan_created";
+pub const ACT_TIER_CHANGED: &str = "tier_changed";
 pub const ACT_PAYMENT_PROCESSED: &str = "payment_ok";
-pub const ACT_PAYMENT_FAILED: &str  = "payment_fail";
+pub const ACT_PAYMENT_FAILED: &str = "payment_fail";
 pub const ACT_PAYMENT_RETRIED: &str = "payment_retry";
 
 // =========== Multisig-specific actions ===========
 
-pub const ACT_PROPOSED_OP: &str  = "proposed_op";
-pub const ACT_SIGNED: &str       = "signed";
+pub const ACT_PROPOSED_OP: &str = "proposed_op";
+pub const ACT_SIGNED: &str = "signed";
 pub const ACT_SIGNER_ADDED: &str = "signer_added";
 pub const ACT_SIGNER_REMOVED: &str = "signer_removed";
-pub const ACT_FROZEN: &str       = "frozen";
-pub const ACT_UNFROZEN: &str     = "unfrozen";
-pub const ACT_POLICY_SET: &str   = "policy_set";
+pub const ACT_FROZEN: &str = "frozen";
+pub const ACT_UNFROZEN: &str = "unfrozen";
+pub const ACT_POLICY_SET: &str = "policy_set";
 
 // =========== Allowance-specific actions ===========
 
-pub const ACT_GRANTED: &str   = "granted";
-pub const ACT_REVOKED: &str   = "revoked";
+pub const ACT_GRANTED: &str = "granted";
+pub const ACT_REVOKED: &str = "revoked";
 pub const ACT_INCREASED: &str = "increased";
 pub const ACT_DECREASED: &str = "decreased";
 

--- a/contract/src/events/types.rs
+++ b/contract/src/events/types.rs
@@ -1,4 +1,4 @@
-﻿/// Standardized event types for the Stellar Guilds platform.
+/// Standardized event types for the Stellar Guilds platform.
 ///
 /// Every event emitted across all contract modules is wrapped in a consistent
 /// `EventEnvelope` that carries versioning, timing, and correlation metadata.
@@ -18,7 +18,6 @@
 /// Never call `env.events().publish()` directly from module code.
 /// Always go through `emit::emit_event()` so the envelope is populated
 /// consistently and the sequence counter is incremented atomically.
-
 use soroban_sdk::{contracttype, Symbol};
 
 /// Current event schema version. Increment on any breaking envelope change.

--- a/contract/src/guild/membership.rs
+++ b/contract/src/guild/membership.rs
@@ -1,10 +1,11 @@
 ﻿use crate::events::emit::emit_event;
 use crate::events::topics::{
-    ACT_CREATED, ACT_MEMBER_ADDED, ACT_MEMBER_REMOVED, ACT_ROLE_UPDATED, MOD_GUILD,
+    ACT_CREATED, ACT_JOINED, ACT_MEMBER_ADDED, ACT_MEMBER_REMOVED, ACT_ROLE_UPDATED, MOD_GUILD,
 };
 use crate::guild::storage;
 use crate::guild::types::{
-    Guild, GuildCreatedEvent, Member, MemberAddedEvent, MemberRemovedEvent, Role, RoleUpdatedEvent,
+    Guild, GuildCreatedEvent, GuildJoinedEvent, Member, MemberAddedEvent, MemberRemovedEvent, Role,
+    RoleUpdatedEvent,
 };
 use soroban_sdk::{Address, Env, String, Vec};
 
@@ -330,7 +331,65 @@ pub fn update_role(
     Ok(true)
 }
 
-// â”€â”€â”€ Query helpers (no events) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+/// Self-join a guild
+///
+/// Allows any address to add themselves to an existing guild as a `Member`.
+/// The caller **must** have signed the transaction — `caller.require_auth()`
+/// is enforced inside this function so that the Soroban runtime verifies the
+/// authorization before any state is written.
+///
+/// # Events emitted
+/// - `(guild, joined)` → `GuildJoinedEvent`
+///
+/// # Arguments
+/// * `env`      - The contract environment
+/// * `guild_id` - The ID of the guild to join
+/// * `caller`   - The address of the account joining (must sign the transaction)
+///
+/// # Returns
+/// `Ok(true)` on success.
+///
+/// # Errors
+/// - `"Guild not found"` — no guild exists with the given `guild_id`.
+/// - `"Already a member of this guild"` — `caller` is already in the membership map.
+pub fn join_guild(env: &Env, guild_id: u64, caller: Address) -> Result<bool, String> {
+    // Soroban auth: the caller must have signed this invocation.
+    caller.require_auth();
+
+    let guild =
+        storage::get_guild(env, guild_id).ok_or(String::from_str(env, "Guild not found"))?;
+
+    if storage::has_member(env, guild_id, &caller) {
+        return Err(String::from_str(env, "Already a member of this guild"));
+    }
+
+    let timestamp = env.ledger().timestamp();
+    let member = Member {
+        address: caller.clone(),
+        role: Role::Member,
+        joined_at: timestamp,
+    };
+    storage::store_member(env, guild_id, &member);
+
+    let mut updated_guild = guild;
+    updated_guild.member_count += 1;
+    storage::update_guild(env, &updated_guild);
+
+    emit_event(
+        env,
+        MOD_GUILD,
+        ACT_JOINED,
+        GuildJoinedEvent {
+            guild_id,
+            caller,
+            joined_at: timestamp,
+        },
+    );
+
+    Ok(true)
+}
+
+// ─── Query helpers (no events) ────────────────────────────────────────────────
 
 pub fn get_member(env: &Env, guild_id: u64, address: Address) -> Result<Member, String> {
     storage::get_member(env, guild_id, &address).ok_or(String::from_str(env, "Member not found"))

--- a/contract/src/guild/mod.rs
+++ b/contract/src/guild/mod.rs
@@ -10,3 +10,6 @@ pub mod storage;
 /// - `storage`: Manages persistent storage of guilds and members
 /// - `membership`: Core functions for guild and member management
 pub mod types;
+
+#[cfg(test)]
+pub mod tests;

--- a/contract/src/guild/tests.rs
+++ b/contract/src/guild/tests.rs
@@ -1,0 +1,127 @@
+//! Guild membership tests — join_guild
+//!
+//! Covers authorized self-join, duplicate join rejection, join on a
+//! non-existent guild, and unauthorized join (missing signature).
+
+#![cfg(test)]
+
+use crate::guild::types::Role;
+use crate::{StellarGuildsContract, StellarGuildsContractClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, String};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+fn setup_env() -> Env {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    env
+}
+
+fn register_and_init(env: &Env) -> Address {
+    let contract_id = env.register_contract(None, StellarGuildsContract);
+    let client = StellarGuildsContractClient::new(env, &contract_id);
+    client.initialize(&Address::generate(env));
+    contract_id
+}
+
+fn create_test_guild(client: &StellarGuildsContractClient<'_>, env: &Env, owner: &Address) -> u64 {
+    client.create_guild(
+        &String::from_str(env, "Test Guild"),
+        &String::from_str(env, "A guild for testing"),
+        owner,
+    )
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+/// An address that signs its own transaction can successfully join a guild
+/// and is thereafter visible as a `Role::Member` in the membership map.
+#[test]
+fn test_join_guild_authorized() {
+    let env = setup_env();
+    env.mock_all_auths();
+
+    let contract_id = register_and_init(&env);
+    let client = StellarGuildsContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let guild_id = create_test_guild(&client, &env, &owner);
+
+    let joiner = Address::generate(&env);
+    assert!(
+        !client.is_member(&guild_id, &joiner),
+        "should not be a member yet"
+    );
+
+    let result = client.join_guild(&guild_id, &joiner);
+    assert!(result, "join_guild should return true");
+
+    // Verify membership and role
+    assert!(
+        client.is_member(&guild_id, &joiner),
+        "should now be a member"
+    );
+    let member = client.get_member(&guild_id, &joiner);
+    assert_eq!(member.role, Role::Member, "default role should be Member");
+    assert_eq!(member.address, joiner);
+
+    // Verify guild member_count incremented (owner = 1, joiner = 2)
+    let all = client.get_all_members(&guild_id);
+    assert_eq!(all.len(), 2u32);
+}
+
+/// Joining a guild that does not exist must panic with "Guild not found".
+#[test]
+#[should_panic(expected = "Guild not found")]
+fn test_join_nonexistent_guild_panics() {
+    let env = setup_env();
+    env.mock_all_auths();
+
+    let contract_id = register_and_init(&env);
+    let client = StellarGuildsContractClient::new(&env, &contract_id);
+
+    let joiner = Address::generate(&env);
+    client.join_guild(&999u64, &joiner);
+}
+
+/// Attempting to join a guild the caller has already joined must panic
+/// with "Already a member of this guild".
+#[test]
+#[should_panic(expected = "Already a member of this guild")]
+fn test_join_guild_duplicate_panics() {
+    let env = setup_env();
+    env.mock_all_auths();
+
+    let contract_id = register_and_init(&env);
+    let client = StellarGuildsContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let guild_id = create_test_guild(&client, &env, &owner);
+
+    let joiner = Address::generate(&env);
+    client.join_guild(&guild_id, &joiner); // first join — ok
+    client.join_guild(&guild_id, &joiner); // second join — must panic
+}
+
+/// A caller who has NOT authorised the transaction must NOT be able to join.
+/// Soroban's `require_auth` panics when no matching authorisation is present.
+#[test]
+#[should_panic]
+fn test_join_guild_unauthorized_panics() {
+    let env = setup_env();
+    // Intentionally do NOT call env.mock_all_auths() so auth checks are live.
+
+    let contract_id = register_and_init(&env);
+    let client = StellarGuildsContractClient::new(&env, &contract_id);
+
+    // Neither initialize nor create_guild call require_auth, so no auth mock
+    // is needed for setup. The env has no mocked auths at all, which means
+    // caller.require_auth() inside join_guild will panic as expected.
+    let owner = Address::generate(&env);
+    let guild_id = create_test_guild(&client, &env, &owner);
+
+    let joiner = Address::generate(&env);
+    // No mock_all_auths → require_auth() inside join_guild panics.
+    client.join_guild(&guild_id, &joiner);
+}

--- a/contract/src/guild/types.rs
+++ b/contract/src/guild/types.rs
@@ -82,6 +82,15 @@ pub struct GuildCreatedEvent {
     pub created_at: u64,
 }
 
+/// Event emitted when a member self-joins a guild
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct GuildJoinedEvent {
+    pub guild_id: u64,
+    pub caller: Address,
+    pub joined_at: u64,
+}
+
 /// Event emitted when a member is added
 #[contracttype]
 #[derive(Clone, Debug)]

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,11 +1,11 @@
-﻿#![no_std]
+#![no_std]
 
 use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 mod events;
 mod guild;
 use guild::membership::{
-    add_member, create_guild, get_all_members, get_member, has_permission, is_member,
+    add_member, create_guild, get_all_members, get_member, has_permission, is_member, join_guild,
     remove_member, update_role,
 };
 use guild::storage;
@@ -13,9 +13,8 @@ use guild::types::{Member, Role};
 
 mod bounty;
 use bounty::{
-    approve_bounty, approve_completion, cancel_bounty, claim_bounty, create_bounty,
-    expire_bounty, fund_bounty, get_bounty_data, get_guild_bounties_list, release_escrow,
-    submit_work, Bounty,
+    approve_bounty, approve_completion, cancel_bounty, claim_bounty, create_bounty, expire_bounty,
+    fund_bounty, get_bounty_data, get_guild_bounties_list, release_escrow, submit_work, Bounty,
 };
 
 mod treasury;
@@ -316,6 +315,24 @@ impl StellarGuildsContract {
     /// true if the address is a member, false otherwise
     pub fn is_member(env: Env, guild_id: u64, address: Address) -> bool {
         is_member(&env, guild_id, address)
+    }
+
+    /// Join an existing guild as a member
+    ///
+    /// The caller must sign the transaction. They will be added with
+    /// `Role::Member` if not already present.
+    ///
+    /// # Arguments
+    /// * `guild_id` - The ID of the guild to join
+    /// * `caller`   - The address joining (must auth)
+    ///
+    /// # Returns
+    /// true if successful, panics otherwise
+    pub fn join_guild(env: Env, guild_id: u64, caller: Address) -> bool {
+        match join_guild(&env, guild_id, caller) {
+            Ok(result) => result,
+            Err(e) => panic!("{:?}", e),
+        }
     }
 
     /// Check if a member has permission for a required role
@@ -2074,7 +2091,11 @@ impl StellarGuildsContract {
         initial_version_patch: u32,
         governance_address: Address,
     ) -> bool {
-        let version = Version::new(initial_version_major, initial_version_minor, initial_version_patch);
+        let version = Version::new(
+            initial_version_major,
+            initial_version_minor,
+            initial_version_patch,
+        );
         upgrade_storage::initialize(&env, version, governance_address);
         true
     }
@@ -2089,8 +2110,18 @@ impl StellarGuildsContract {
         target_version_patch: u32,
         description: String,
     ) -> u64 {
-        let target_version = Version::new(target_version_major, target_version_minor, target_version_patch);
-        upgrade_logic::propose_upgrade(&env, &proposer, &new_contract_address, &target_version, description)
+        let target_version = Version::new(
+            target_version_major,
+            target_version_minor,
+            target_version_patch,
+        );
+        upgrade_logic::propose_upgrade(
+            &env,
+            &proposer,
+            &new_contract_address,
+            &target_version,
+            description,
+        )
     }
 
     /// Vote on an upgrade proposal
@@ -2107,11 +2138,7 @@ impl StellarGuildsContract {
     }
 
     /// Execute an approved upgrade
-    pub fn execute_upgrade_proposal(
-        env: Env,
-        executor: Address,
-        proposal_id: u64,
-    ) -> bool {
+    pub fn execute_upgrade_proposal(env: Env, executor: Address, proposal_id: u64) -> bool {
         match upgrade_logic::execute_upgrade(&env, &executor, proposal_id) {
             Ok(_) => true,
             Err(_) => false,
@@ -2135,11 +2162,7 @@ impl StellarGuildsContract {
     }
 
     /// Toggle emergency upgrades on/off
-    pub fn toggle_emergency_upgrades(
-        env: Env,
-        caller: Address,
-        enable: bool,
-    ) -> bool {
+    pub fn toggle_emergency_upgrades(env: Env, caller: Address, enable: bool) -> bool {
         match upgrade_logic::toggle_emergency_upgrades(&env, &caller, enable) {
             Ok(_) => true,
             Err(_) => false,
@@ -2182,21 +2205,13 @@ impl StellarGuildsContract {
     // ============ Proxy Functions ============
 
     /// Initialize proxy functionality
-    pub fn initialize_proxy(
-        env: Env,
-        initial_implementation: Address,
-        admin: Address,
-    ) -> bool {
+    pub fn initialize_proxy(env: Env, initial_implementation: Address, admin: Address) -> bool {
         proxy_storage::initialize(&env, initial_implementation, admin);
         true
     }
 
     /// Upgrade the proxy to a new implementation
-    pub fn proxy_upgrade(
-        env: Env,
-        caller: Address,
-        new_implementation: Address,
-    ) -> bool {
+    pub fn proxy_upgrade(env: Env, caller: Address, new_implementation: Address) -> bool {
         match proxy_impl::upgrade(&env, &caller, &new_implementation) {
             Ok(_) => true,
             Err(_) => false,
@@ -2204,11 +2219,7 @@ impl StellarGuildsContract {
     }
 
     /// Transfer admin rights of the proxy
-    pub fn proxy_transfer_admin(
-        env: Env,
-        caller: Address,
-        new_admin: Address,
-    ) -> bool {
+    pub fn proxy_transfer_admin(env: Env, caller: Address, new_admin: Address) -> bool {
         match proxy_impl::transfer_admin(&env, &caller, &new_admin) {
             Ok(_) => true,
             Err(_) => false,
@@ -2226,10 +2237,7 @@ impl StellarGuildsContract {
     }
 
     /// Trigger emergency stop for the proxy
-    pub fn proxy_emergency_stop(
-        env: Env,
-        caller: Address,
-    ) -> bool {
+    pub fn proxy_emergency_stop(env: Env, caller: Address) -> bool {
         match proxy_impl::emergency_stop(&env, &caller) {
             Ok(_) => true,
             Err(_) => false,
@@ -2237,10 +2245,7 @@ impl StellarGuildsContract {
     }
 
     /// Resume proxy after emergency stop
-    pub fn proxy_resume(
-        env: Env,
-        caller: Address,
-    ) -> bool {
+    pub fn proxy_resume(env: Env, caller: Address) -> bool {
         match proxy_impl::resume(&env, &caller) {
             Ok(_) => true,
             Err(_) => false,

--- a/contract/src/payment/distribution.rs
+++ b/contract/src/payment/distribution.rs
@@ -1,7 +1,6 @@
-﻿use crate::events::emit::emit_event;
+use crate::events::emit::emit_event;
 use crate::events::topics::{
-    ACT_CANCELLED, ACT_DISTRIBUTED, ACT_FAILED, ACT_RECIPIENT_ADDED, MOD_PAYMENT,
-    ACT_CREATED,
+    ACT_CANCELLED, ACT_CREATED, ACT_DISTRIBUTED, ACT_FAILED, ACT_RECIPIENT_ADDED, MOD_PAYMENT,
 };
 use crate::payment::storage::{
     add_recipient_to_pool, clear_pool_recipients, get_next_pool_id, get_payment_pool,

--- a/contract/src/proxy/implementation.rs
+++ b/contract/src/proxy/implementation.rs
@@ -1,25 +1,33 @@
-﻿use crate::proxy::storage;
+use crate::proxy::storage;
 use crate::proxy::types::{ProxyConfig, UpgradeTransaction};
 use soroban_sdk::{symbol_short, Address, Env};
 
-
-
 /// Upgrade the proxy to a new implementation
-pub fn upgrade(env: &Env, caller: &Address, new_implementation: &Address) -> Result<(), &'static str> {
+pub fn upgrade(
+    env: &Env,
+    caller: &Address,
+    new_implementation: &Address,
+) -> Result<(), &'static str> {
     caller.require_auth();
-    
+
     // Check if the caller is authorized to perform upgrades
     if !storage::is_admin(env, caller) {
         return Err("Only admin can perform upgrades");
     }
-    
+
     // Validate that the new implementation is a valid contract address
     // In a real implementation, we might want to validate the contract
-    
+
     // Record the upgrade transaction before performing the upgrade
-    let upgrade_id = env.storage().instance().get(&symbol_short!("nxt_upg")).unwrap_or(1u64);
-    env.storage().instance().set(&symbol_short!("nxt_upg"), &(upgrade_id + 1));
-    
+    let upgrade_id = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("nxt_upg"))
+        .unwrap_or(1u64);
+    env.storage()
+        .instance()
+        .set(&symbol_short!("nxt_upg"), &(upgrade_id + 1));
+
     let upgrade_tx = UpgradeTransaction {
         id: upgrade_id,
         new_implementation: new_implementation.clone(),
@@ -28,83 +36,90 @@ pub fn upgrade(env: &Env, caller: &Address, new_implementation: &Address) -> Res
         success: true, // Assume success for now
         failure_reason: None,
     };
-    
+
     // Perform the upgrade by setting the new implementation
     storage::set_implementation(env, new_implementation);
-    
+
     // Record the upgrade transaction
     storage::record_upgrade_transaction(env, &upgrade_tx);
-    
+
     // Emit upgrade event
-    env.events()
-        .publish(("proxy", "upgraded"), (upgrade_id, new_implementation.clone()));
-    
+    env.events().publish(
+        ("proxy", "upgraded"),
+        (upgrade_id, new_implementation.clone()),
+    );
+
     Ok(())
 }
 
 /// Transfer admin rights to a new address
-pub fn transfer_admin(env: &Env, caller: &Address, new_admin: &Address) -> Result<(), &'static str> {
+pub fn transfer_admin(
+    env: &Env,
+    caller: &Address,
+    new_admin: &Address,
+) -> Result<(), &'static str> {
     caller.require_auth();
-    
+
     // Only current admin can transfer admin rights
     if !storage::is_admin(env, caller) {
         return Err("Only admin can transfer admin rights");
     }
-    
+
     // Update the admin
     storage::set_admin(env, new_admin);
-    
+
     // Emit admin transfer event
-    env.events()
-        .publish(("proxy", "admin_transferred"), (caller.clone(), new_admin.clone()));
-    
+    env.events().publish(
+        ("proxy", "admin_transferred"),
+        (caller.clone(), new_admin.clone()),
+    );
+
     Ok(())
 }
 
 /// Accept admin rights (if transferred by current admin)
 pub fn accept_admin(env: &Env, new_admin: &Address) -> Result<(), &'static str> {
     new_admin.require_auth();
-    
+
     // In a real implementation, this would involve a two-step process
     // where the new admin accepts the transfer
     // For simplicity, we'll just emit an event
     env.events()
         .publish(("proxy", "admin_accepted"), new_admin.clone());
-    
+
     Ok(())
 }
 
 /// Emergency stop functionality to pause upgrades
 pub fn emergency_stop(env: &Env, caller: &Address) -> Result<(), &'static str> {
     caller.require_auth();
-    
+
     // Only admin can trigger emergency stop
     if !storage::is_admin(env, caller) {
         return Err("Only admin can trigger emergency stop");
     }
-    
+
     // In a real implementation, this would set a paused state
     // For now, we'll just emit an event
     env.events()
         .publish(("proxy", "emergency_stop"), caller.clone());
-    
+
     Ok(())
 }
 
 /// Resume after emergency stop
 pub fn resume(env: &Env, caller: &Address) -> Result<(), &'static str> {
     caller.require_auth();
-    
+
     // Only admin can resume
     if !storage::is_admin(env, caller) {
         return Err("Only admin can resume");
     }
-    
+
     // In a real implementation, this would unset a paused state
     // For now, we'll just emit an event
-    env.events()
-        .publish(("proxy", "resume"), caller.clone());
-    
+    env.events().publish(("proxy", "resume"), caller.clone());
+
     Ok(())
 }
 

--- a/contract/src/proxy/mod.rs
+++ b/contract/src/proxy/mod.rs
@@ -1,3 +1,3 @@
-﻿pub mod types;
-pub mod storage;
 pub mod implementation;
+pub mod storage;
+pub mod types;

--- a/contract/src/proxy/storage.rs
+++ b/contract/src/proxy/storage.rs
@@ -1,4 +1,4 @@
-﻿use crate::proxy::types::{ProxyConfig, UpgradeTransaction};
+use crate::proxy::types::{ProxyConfig, UpgradeTransaction};
 use soroban_sdk::{symbol_short, Address, Env, Map, Symbol};
 
 // Storage keys for proxy functionality
@@ -15,15 +15,19 @@ pub fn initialize(env: &Env, initial_implementation: Address, admin: Address) {
         version: 1, // Start with version 1
         last_updated: env.ledger().timestamp(),
     };
-    
+
     env.storage().persistent().set(&PROXY_CONFIG_KEY, &config);
-    
+
     // Also store implementation in a dedicated slot for easy access
-    env.storage().persistent().set(&IMPLEMENTATION_SLOT, &config.implementation);
-    
+    env.storage()
+        .persistent()
+        .set(&IMPLEMENTATION_SLOT, &config.implementation);
+
     // Initialize upgrade history
     let upgrade_history: Map<u64, UpgradeTransaction> = Map::new(env);
-    env.storage().persistent().set(&UPGRADE_HISTORY_KEY, &upgrade_history);
+    env.storage()
+        .persistent()
+        .set(&UPGRADE_HISTORY_KEY, &upgrade_history);
 }
 
 /// Get the current proxy configuration
@@ -44,14 +48,16 @@ pub fn get_implementation(env: &Env) -> Address {
 
 /// Set a new implementation address
 pub fn set_implementation(env: &Env, implementation: &Address) {
-    env.storage().persistent().set(&IMPLEMENTATION_SLOT, implementation);
-    
+    env.storage()
+        .persistent()
+        .set(&IMPLEMENTATION_SLOT, implementation);
+
     // Also update the config
     let mut config = get_proxy_config(env);
     config.implementation = implementation.clone();
     config.version += 1; // Increment version
     config.last_updated = env.ledger().timestamp();
-    
+
     env.storage().persistent().set(&PROXY_CONFIG_KEY, &config);
 }
 
@@ -66,7 +72,7 @@ pub fn set_admin(env: &Env, admin: &Address) {
     let mut config = get_proxy_config(env);
     config.admin = admin.clone();
     config.last_updated = env.ledger().timestamp();
-    
+
     env.storage().persistent().set(&PROXY_CONFIG_KEY, &config);
 }
 

--- a/contract/src/test_init.rs
+++ b/contract/src/test_init.rs
@@ -1,4 +1,4 @@
-﻿#![cfg(test)]
+#![cfg(test)]
 
 use crate::{StellarGuildsContract, StellarGuildsContractClient};
 use soroban_sdk::{testutils::Address as _, Address, Env};
@@ -10,7 +10,7 @@ fn test_initialize_success() {
     let client = StellarGuildsContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    
+
     // First initialization should succeed
     assert!(client.initialize(&admin));
 }
@@ -23,9 +23,9 @@ fn test_initialize_twice_panics() {
     let client = StellarGuildsContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    
+
     client.initialize(&admin);
-    
+
     // Second initialization should panic
     client.initialize(&admin);
 }

--- a/contract/src/upgrade/logic.rs
+++ b/contract/src/upgrade/logic.rs
@@ -1,4 +1,4 @@
-﻿use crate::upgrade::storage;
+use crate::upgrade::storage;
 use crate::upgrade::types::{MigrationPlan, UpgradeProposal, UpgradeStatus, Version};
 use soroban_sdk::{symbol_short, Address, Env, String};
 
@@ -16,10 +16,16 @@ pub fn propose_upgrade(
 
     // In a real implementation, we might check if the proposer has sufficient voting power
     // For now, we just verify the governance address
-    
+
     // Generate a new proposal ID (in practice, this might be more sophisticated)
-    let proposal_id = env.storage().instance().get(&symbol_short!("nxt_prop")).unwrap_or(1u64);
-    env.storage().instance().set(&symbol_short!("nxt_prop"), &(proposal_id + 1));
+    let proposal_id = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("nxt_prop"))
+        .unwrap_or(1u64);
+    env.storage()
+        .instance()
+        .set(&symbol_short!("nxt_prop"), &(proposal_id + 1));
 
     let proposal = UpgradeProposal {
         id: proposal_id,
@@ -51,16 +57,16 @@ pub fn vote_on_proposal(
     vote_for: bool,
 ) -> Result<(), &'static str> {
     voter.require_auth();
-    
+
     // Record the vote
     storage::record_vote(env, proposal_id, voter, vote_for)?;
-    
+
     // Check if proposal has reached required threshold
     if let Some(proposal) = storage::get_upgrade_proposal(env, proposal_id) {
         let _total_votes = proposal.votes_for + proposal.votes_against;
         // Simple majority threshold - in real implementation this could be configurable
         let required_votes = (proposal.total_voters / 2) + 1;
-        
+
         if proposal.votes_for >= required_votes {
             storage::update_proposal_status(env, proposal_id, UpgradeStatus::Approved);
             env.events()
@@ -71,43 +77,46 @@ pub fn vote_on_proposal(
                 .publish(("upgrade", "proposal_rejected"), proposal_id);
         }
     }
-    
+
     Ok(())
 }
 
 /// Execute an approved upgrade
-pub fn execute_upgrade(env: &Env, executor: &Address, proposal_id: u64) -> Result<(), &'static str> {
+pub fn execute_upgrade(
+    env: &Env,
+    executor: &Address,
+    proposal_id: u64,
+) -> Result<(), &'static str> {
     executor.require_auth();
-    
-    let mut proposal = storage::get_upgrade_proposal(env, proposal_id)
-        .ok_or("Proposal does not exist")?;
-    
+
+    let mut proposal =
+        storage::get_upgrade_proposal(env, proposal_id).ok_or("Proposal does not exist")?;
+
     if proposal.status != UpgradeStatus::Approved {
         return Err("Proposal is not approved for execution");
     }
-    
+
     // Check if the caller is authorized to execute upgrades
     let governance_addr = storage::get_governance_address(env);
     if *executor != governance_addr {
         return Err("Only governance address can execute upgrades");
     }
-    
+
     // Perform state migration if a migration plan exists
     if let Some(migration_plan) = storage::get_migration_plan(env, proposal_id) {
         perform_state_migration(env, &migration_plan)?;
     }
-    
+
     // Update the current version
     storage::set_current_version(env, &proposal.version);
-    
+
     // Update proposal status
     proposal.status = UpgradeStatus::Executed;
     storage::store_upgrade_proposal(env, &proposal);
-    
+
     // Emit upgrade execution event
-    env.events()
-        .publish(("upgrade", "executed"), proposal_id);
-    
+    env.events().publish(("upgrade", "executed"), proposal_id);
+
     Ok(())
 }
 
@@ -119,43 +128,47 @@ pub fn emergency_upgrade(
     new_version: &Version,
 ) -> Result<(), &'static str> {
     caller.require_auth();
-    
+
     // Check if emergency upgrades are enabled
     if !storage::is_emergency_upgrade_enabled(env) {
         return Err("Emergency upgrades are not enabled");
     }
-    
+
     // Only governance address can perform emergency upgrades
     let governance_addr = storage::get_governance_address(env);
     if *caller != governance_addr {
         return Err("Only governance address can perform emergency upgrades");
     }
-    
+
     // Update the current version directly
     storage::set_current_version(env, new_version);
-    
+
     // Emit emergency upgrade event
     env.events()
         .publish(("upgrade", "emergency_executed"), new_version.clone());
-    
+
     Ok(())
 }
 
 /// Enable or disable emergency upgrades
-pub fn toggle_emergency_upgrades(env: &Env, caller: &Address, enable: bool) -> Result<(), &'static str> {
+pub fn toggle_emergency_upgrades(
+    env: &Env,
+    caller: &Address,
+    enable: bool,
+) -> Result<(), &'static str> {
     caller.require_auth();
-    
+
     // Only governance address can enable/disable emergency upgrades
     let governance_addr = storage::get_governance_address(env);
     if *caller != governance_addr {
         return Err("Only governance address can toggle emergency upgrades");
     }
-    
+
     storage::set_emergency_upgrade_enabled(env, enable);
-    
+
     env.events()
         .publish(("upgrade", "emergency_toggled"), enable);
-    
+
     Ok(())
 }
 
@@ -167,18 +180,18 @@ pub fn register_migration_plan(
     migration_plan: &MigrationPlan,
 ) -> Result<(), &'static str> {
     caller.require_auth();
-    
+
     // Only governance address can register migration plans
     let governance_addr = storage::get_governance_address(env);
     if *caller != governance_addr {
         return Err("Only governance address can register migration plans");
     }
-    
+
     storage::store_migration_plan(env, proposal_id, migration_plan);
-    
+
     env.events()
         .publish(("upgrade", "migration_registered"), proposal_id);
-    
+
     Ok(())
 }
 
@@ -187,17 +200,17 @@ fn perform_state_migration(env: &Env, plan: &MigrationPlan) -> Result<(), &'stat
     // In a real implementation, this would call specific migration functions
     // based on the migration plan's selector
     // For now, we'll just log the migration attempt
-    
+
     env.events()
         .publish(("upgrade", "migration_started"), plan.from_version.clone());
-    
+
     // Placeholder for actual migration logic
     // This would involve calling migration functions that transform data
     // from the old format to the new format
-    
+
     env.events()
         .publish(("upgrade", "migration_completed"), plan.to_version.clone());
-    
+
     Ok(())
 }
 
@@ -215,27 +228,29 @@ pub fn rollback_to_version(
     target_version: &Version,
 ) -> Result<(), &'static str> {
     caller.require_auth();
-    
+
     // Only governance address can perform rollbacks
     let governance_addr = storage::get_governance_address(env);
     if *caller != governance_addr {
         return Err("Only governance address can perform rollbacks");
     }
-    
+
     // In a real implementation, this would involve complex state restoration
     // For now, we'll just check if the rollback is to a previous version
     let current_version = storage::get_current_version(env);
-    
-    if target_version.major != current_version.major || 
-       (target_version.major == current_version.major && target_version.minor > current_version.minor) {
+
+    if target_version.major != current_version.major
+        || (target_version.major == current_version.major
+            && target_version.minor > current_version.minor)
+    {
         return Err("Can only rollback to earlier versions in the same major series");
     }
-    
+
     // Update to the target version
     storage::set_current_version(env, target_version);
-    
+
     env.events()
         .publish(("upgrade", "rollback_completed"), target_version.clone());
-    
+
     Ok(())
 }

--- a/contract/src/upgrade/mod.rs
+++ b/contract/src/upgrade/mod.rs
@@ -1,4 +1,4 @@
-﻿pub mod types;
-pub mod storage;
 pub mod logic;
+pub mod storage;
 pub mod tests;
+pub mod types;

--- a/contract/src/upgrade/storage.rs
+++ b/contract/src/upgrade/storage.rs
@@ -1,4 +1,4 @@
-﻿use crate::upgrade::types::{MigrationPlan, UpgradeProposal, UpgradeStatus, Version};
+use crate::upgrade::types::{MigrationPlan, UpgradeProposal, UpgradeStatus, Version};
 use soroban_sdk::{symbol_short, Address, Env, Map, Symbol, Vec};
 
 // Storage keys for upgrade functionality
@@ -17,21 +17,29 @@ pub fn initialize(env: &Env, initial_version: Version, governance_address: Addre
     env.storage()
         .persistent()
         .set(&GOVERNANCE_ADDRESS_KEY, &governance_address);
-    
+
     // Initialize empty proposals map
     let proposals: Map<u64, UpgradeProposal> = Map::new(env);
-    env.storage().persistent().set(&UPGRADE_PROPOSALS_KEY, &proposals);
-    
+    env.storage()
+        .persistent()
+        .set(&UPGRADE_PROPOSALS_KEY, &proposals);
+
     // Initialize empty voting power map
     let voting_power: Map<Address, u32> = Map::new(env);
-    env.storage().persistent().set(&VOTING_POWER_KEY, &voting_power);
-    
+    env.storage()
+        .persistent()
+        .set(&VOTING_POWER_KEY, &voting_power);
+
     // Initialize empty migration plans map
     let migration_plans: Map<u64, MigrationPlan> = Map::new(env);
-    env.storage().persistent().set(&MIGRATION_PLANS_KEY, &migration_plans);
-    
+    env.storage()
+        .persistent()
+        .set(&MIGRATION_PLANS_KEY, &migration_plans);
+
     // Set emergency upgrade flag to false
-    env.storage().persistent().set(&EMERGENCY_UPGRADE_KEY, &false);
+    env.storage()
+        .persistent()
+        .set(&EMERGENCY_UPGRADE_KEY, &false);
 }
 
 /// Get the current contract version
@@ -44,7 +52,9 @@ pub fn get_current_version(env: &Env) -> Version {
 
 /// Set the current contract version
 pub fn set_current_version(env: &Env, version: &Version) {
-    env.storage().persistent().set(&CURRENT_VERSION_KEY, version);
+    env.storage()
+        .persistent()
+        .set(&CURRENT_VERSION_KEY, version);
 }
 
 /// Get the governance address
@@ -113,7 +123,9 @@ pub fn set_voting_power(env: &Env, address: &Address, power: u32) {
         .unwrap_or_else(|| Map::new(env));
 
     voting_power.set(address.clone(), power);
-    env.storage().persistent().set(&VOTING_POWER_KEY, &voting_power);
+    env.storage()
+        .persistent()
+        .set(&VOTING_POWER_KEY, &voting_power);
 }
 
 /// Get voting power for an address
@@ -134,8 +146,7 @@ pub fn record_vote(
     voter: &Address,
     vote_for: bool,
 ) -> Result<(), &'static str> {
-    let mut proposal = get_upgrade_proposal(env, proposal_id)
-        .ok_or("Proposal does not exist")?;
+    let mut proposal = get_upgrade_proposal(env, proposal_id).ok_or("Proposal does not exist")?;
 
     if proposal.status != UpgradeStatus::Pending {
         return Err("Proposal is not in pending status");
@@ -144,7 +155,7 @@ pub fn record_vote(
     // Check if voter has already voted
     // In a real implementation, we'd track who has voted
     // For simplicity, we'll just update the vote counts
-    
+
     if vote_for {
         proposal.votes_for += get_voting_power(env, voter);
     } else {
@@ -190,5 +201,7 @@ pub fn is_emergency_upgrade_enabled(env: &Env) -> bool {
 
 /// Enable/disable emergency upgrades
 pub fn set_emergency_upgrade_enabled(env: &Env, enabled: bool) {
-    env.storage().persistent().set(&EMERGENCY_UPGRADE_KEY, &enabled);
+    env.storage()
+        .persistent()
+        .set(&EMERGENCY_UPGRADE_KEY, &enabled);
 }

--- a/contract/src/upgrade/tests.rs
+++ b/contract/src/upgrade/tests.rs
@@ -1,4 +1,4 @@
-﻿#![cfg(test)]
+#![cfg(test)]
 
 use super::types::*;
 use soroban_sdk::{testutils::Address as _, Address, Env};
@@ -10,20 +10,20 @@ fn create_test_version(major: u32, minor: u32, patch: u32) -> Version {
 #[test]
 fn test_version_compatibility() {
     let _env = Env::default();
-    
+
     let v1_0_0 = create_test_version(1, 0, 0);
     let v1_1_0 = create_test_version(1, 1, 0);
     let v2_0_0 = create_test_version(2, 0, 0);
-    
+
     // Same version should be compatible
     assert!(v1_0_0.is_compatible_with(&v1_0_0));
-    
+
     // Later minor version should be compatible
     assert!(v1_1_0.is_compatible_with(&v1_0_0));
-    
+
     // Earlier minor version should not be compatible with later
     assert!(!v1_0_0.is_compatible_with(&v1_1_0));
-    
+
     // Different major versions should not be compatible
     assert!(!v2_0_0.is_compatible_with(&v1_0_0));
     assert!(!v1_0_0.is_compatible_with(&v2_0_0));
@@ -44,7 +44,7 @@ fn test_upgrade_status_enum() {
     let executed = UpgradeStatus::Executed;
     let rejected = UpgradeStatus::Rejected;
     let cancelled = UpgradeStatus::Cancelled;
-    
+
     assert_eq!(pending as u32, 0);
     assert_eq!(approved as u32, 1);
     assert_eq!(executed as u32, 2);
@@ -58,14 +58,14 @@ fn test_migration_plan() {
     let from_version = create_test_version(1, 0, 0);
     let to_version = create_test_version(1, 1, 0);
     let selector = soroban_sdk::symbol_short!("migrate");
-    
+
     let migration_plan = MigrationPlan {
         from_version,
         to_version,
         migration_function_selector: selector,
         estimated_gas: 100000,
     };
-    
+
     assert_eq!(migration_plan.from_version.major, 1);
     assert_eq!(migration_plan.to_version.minor, 1);
     assert_eq!(migration_plan.estimated_gas, 100000);

--- a/contract/src/upgrade/types.rs
+++ b/contract/src/upgrade/types.rs
@@ -1,4 +1,4 @@
-﻿use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address};
 
 /// Represents the current version of the contract
 #[contracttype]
@@ -11,7 +11,11 @@ pub struct Version {
 
 impl Version {
     pub fn new(major: u32, minor: u32, patch: u32) -> Self {
-        Version { major, minor, patch }
+        Version {
+            major,
+            minor,
+            patch,
+        }
     }
 
     /// Compare two versions for compatibility


### PR DESCRIPTION
## `join_guild` Implementation

Implemented `join_guild` in `contract/src/guild/membership.rs`:  Closes #106 

- Accepts a `caller: Address` and calls `caller.require_auth()` to enforce Soroban signing
- Panics if the guild does not exist or the caller is already a member
- Stores the membership entry in the `Membership` map keyed by `(guild_id, caller)`

**Tests added** (`src/guild/tests.rs`):
- `test_join_guild_authorized` — happy path, member stored correctly
- `test_join_guild_unauthorized_panics` — no auth mock, verifies panic
- `test_join_guild_duplicate_panics` — re-join panics with `AlreadyMember`
- `test_join_nonexistent_guild_panics` — invalid guild id panics with `GuildNotFound`

All 4 tests pass. ✅

<img width="599" height="208" alt="image" src="https://github.com/user-attachments/assets/447643b8-6afa-4da5-b8d5-f4762af5183e" />
