### PR TITLE
feat(backend): generic PaginationDto with class-validator + PaginatedResponse (fixes #264)

### DIFF
--- a/backend/src/bounty/bounty.controller.ts
+++ b/backend/src/bounty/bounty.controller.ts
@@ -19,6 +19,7 @@ import { CreateMilestoneDto } from './dto/create-milestone.dto';
 import { ReviewWorkDto } from './dto/review-work.dto';
 import { SubmitBountyWorkDto } from './dto/submit-work.dto';
 import { FindBountyDto } from './dto/find-bounty.dto';
+import { PaginationDto } from '../common/dto/pagination.dto';
 
 @Controller('bounties')
 export class BountyController {
@@ -31,8 +32,8 @@ export class BountyController {
   }
 
   @Get('open')
-  async findAll(@Query() filters: FindBountyDto) {
-    return this.service.findAll(filters);
+  async findAll(@Query() filters: FindBountyDto, @Query() pagination: PaginationDto) {
+    return this.service.findAll({ ...filters, ...pagination });
   }
 
   @Get(':id')

--- a/backend/src/common/dto/pagination.dto.ts
+++ b/backend/src/common/dto/pagination.dto.ts
@@ -1,0 +1,25 @@
+import { IsOptional, IsInt, Min, Max, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * Reusable pagination DTO for all list endpoints.
+ * Supports both cursor-based and page-based pagination.
+ */
+export class PaginationDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  page?: number;
+}

--- a/backend/src/common/types/paginated-response.types.ts
+++ b/backend/src/common/types/paginated-response.types.ts
@@ -1,0 +1,9 @@
+/**
+ * Standardized paginated response envelope for all list endpoints.
+ * Enforces { data: T[], nextCursor: string | null } structure.
+ */
+export interface PaginatedResponse<T> {
+  data: T[];
+  nextCursor: string | null;
+  total?: number;
+}


### PR DESCRIPTION
Fixes #264

## Summary

Adds a reusable, validated pagination DTO and response type for all list endpoints.

## Changes

### New files
- **`backend/src/common/dto/pagination.dto.ts`** — `PaginationDto` class with:
  - `limit`: optional int, `@Min(1) @Max(100)`, defaults to `20`
  - `cursor`: optional string for cursor-based pagination
  - `page`: optional int for page-based fallback (`@Min(0)`)
  - Uses `class-validator` + `class-transformer` decorators

- **`backend/src/common/types/paginated-response.types.ts`** — `PaginatedResponse<T>` interface:
  - Enforces `{ data: T[], nextCursor: string | null, total?: number }`

### Modified
- **`backend/src/bounty/bounty.controller.ts`** — `findAll()` now accepts `PaginationDto` via `@Query()`, merges with existing `FindBountyDto` filters

## Acceptance Criteria
- ✅ `src/common/dto/pagination.dto.ts` with `@Max(100)` / `@Min(1)` on limit
- ✅ Default limit = 20 when empty
- ✅ `PaginatedResponse<T>` interface with `{ data, nextCursor }`
- ✅ Integrated into `BountyController.findAll`

## How to verify
```bash
cd backend
npm run build
# Test: GET /bounties/open?limit=50&cursor=abc123 → validates limit in [1,100]
# Test: GET /bounties/open?limit=999 → rejected (max 100)
# Test: GET /bounties/open → defaults to limit=20
```