### PR TITLE
[Backend] Admin 'Ban Hammer' API (Disable Users)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -66,6 +66,7 @@ model User {
   avatarUrl     String?
   role          UserRole  @default(USER)
   isActive      Boolean   @default(true)
+  banned        Boolean   @default(false)
   lastLoginAt   DateTime?
   walletAddress String?   @unique
   refreshToken  String?

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ForbiddenException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
 
 interface JwtPayload {
   sub: string;
@@ -14,7 +15,10 @@ interface JwtPayload {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private configService: ConfigService) {
+  constructor(
+    private configService: ConfigService,
+    private prisma: PrismaService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -23,6 +27,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload) {
+    // Check if user is banned
+    const user = await this.prisma.user.findUnique({
+      where: { id: payload.sub },
+      select: { banned: true },
+    });
+
+    if (user?.banned) {
+      throw new ForbiddenException('Your account has been banned');
+    }
+
     return {
       userId: payload.sub,
       email: payload.email,

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -221,4 +221,16 @@ export class UserController {
   async reactivateUser(@Param('userId') userId: string) {
     return this.userService.reactivateUser(userId);
   }
+
+  /**
+   * Admin: Ban a user (disable their account globally)
+   */
+  @Post(':userId/ban')
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Ban a user (admin only)' })
+  async banUser(@Param('userId') userId: string) {
+    return this.userService.banUser(userId);
+  }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -405,6 +405,23 @@ export class UserService {
     return { message: 'User account reactivated successfully' };
   }
 
+  async banUser(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { banned: true, isActive: false },
+    });
+
+    return { message: 'User has been banned successfully' };
+  }
+
   // Existing basic CRUD methods (kept for compatibility)
   async user(userWhereUniqueInput: any): Promise<any | null> {
     return this.prisma.user.findUnique({


### PR DESCRIPTION
Fixes #265

## Changes
- **Prisma Schema**: Added `banned` Boolean field to User model (defaults to `false`)
- **UserController**: Added `POST /users/:userId/ban` endpoint protected by `JwtAuthGuard` + `RoleGuard` with `Roles(ADMIN)`
- **UserService**: Added `banUser()` method that sets `banned = true` and `isActive = false`
- **JwtStrategy**: Updated validate() to query DB for banned status and throw `403 Forbidden` if user is banned — this blocks **all** authenticated routes for banned users instantly

## Acceptance Criteria Met
- [x] User model possesses a `banned` Boolean column (defaulting to false)
- [x] Build `POST /admin/users/:id/ban` protected by an AdminGuard (`POST /users/:id/ban` with RoleGuard)
- [x] The endpoint flips `banned = true`
- [x] Auth Guard (JwtStrategy) throws `403 Forbidden` if `req.user.banned` equals true on any secured route

## How to Verify
1. Run `npx prisma migrate dev --name add_banned_field` to apply schema change
2. Start the server with `npm run start:dev`
3. Register/login as admin, get JWT token
4. Call `POST /users/:userId/ban` with admin token → user is banned
5. Try any authenticated endpoint with the banned user's token → 403 Forbidden