### PR TITLE
[Backend] Abstract Audit Logging System

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -292,3 +292,15 @@ model PrivacySettings {
   allowMessagesFromNonFollowers Boolean @default(false)
   showAchievements              Boolean @default(true)
 }
+
+model AuditLog {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  userId    String
+  action    String
+  entityType String?
+  entityId   String?
+  metadata  Json?
+
+  @@map("audit_logs")
+}

--- a/backend/src/audit/audit.interceptor.ts
+++ b/backend/src/audit/audit.interceptor.ts
@@ -1,0 +1,76 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable, tap } from 'rxjs';
+import { AuditService } from './audit.service';
+import { AUDIT_ACTION_KEY } from './log-audit.decorator';
+
+@Injectable()
+export class AuditLogInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(AuditLogInterceptor.name);
+
+  constructor(
+    private reflector: Reflector,
+    private auditService: AuditService,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const action = this.reflector.get<string>(
+      AUDIT_ACTION_KEY,
+      context.getHandler(),
+    );
+
+    if (!action) {
+      return next.handle();
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const userId = user?.userId;
+    const params = request.params;
+
+    // Determine entity type and ID from route params
+    let entityType: string | undefined;
+    let entityId: string | undefined;
+
+    if (params.guildId) {
+      entityType = 'GUILD';
+      entityId = params.guildId;
+    } else if (params.userId) {
+      entityType = 'USER';
+      entityId = params.userId;
+    } else if (params.bountyId) {
+      entityType = 'BOUNTY';
+      entityId = params.bountyId;
+    }
+
+    return next.handle().pipe(
+      tap({
+        next: () => {
+          // Log after successful handler execution
+          this.auditService.recordAction({
+            userId,
+            action,
+            entityType,
+            entityId,
+            metadata: {
+              method: request.method,
+              url: request.url,
+              ip: request.ip,
+            },
+          });
+        },
+        error: (err) => {
+          this.logger.warn(
+            `Audit: action ${action} failed for user ${userId}: ${err.message}`,
+          );
+        },
+      }),
+    );
+  }
+}

--- a/backend/src/audit/audit.module.ts
+++ b/backend/src/audit/audit.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuditService } from './audit.service';
+import { AuditLogInterceptor } from './audit.interceptor';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [AuditService, AuditLogInterceptor],
+  exports: [AuditService, AuditLogInterceptor],
+  controllers: [],
+})
+export class AuditModule {}

--- a/backend/src/audit/audit.service.spec.ts
+++ b/backend/src/audit/audit.service.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditService } from './audit.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('AuditService', () => {
+  let service: AuditService;
+  let prisma: {
+    auditLog: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      count: jest.Mock;
+    };
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      auditLog: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        count: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<AuditService>(AuditService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('recordAction', () => {
+    it('should create an audit log entry with correct data', async () => {
+      const mockEntry = {
+        id: 'audit-1',
+        userId: 'user-1',
+        action: 'BOUNTY_DELETE',
+        entityType: 'BOUNTY',
+        entityId: 'bounty-1',
+        metadata: {},
+        createdAt: new Date(),
+      };
+
+      prisma.auditLog.create.mockResolvedValue(mockEntry);
+
+      const result = await service.recordAction({
+        userId: 'user-1',
+        action: 'BOUNTY_DELETE',
+        entityType: 'BOUNTY',
+        entityId: 'bounty-1',
+      });
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          userId: 'user-1',
+          action: 'BOUNTY_DELETE',
+          entityType: 'BOUNTY',
+          entityId: 'bounty-1',
+          metadata: {},
+        },
+      });
+      expect(result).toEqual(mockEntry);
+    });
+
+    it('should handle DB errors gracefully without throwing', async () => {
+      prisma.auditLog.create.mockRejectedValue(new Error('DB connection lost'));
+
+      const result = await service.recordAction({
+        userId: 'user-1',
+        action: 'TEST_ACTION',
+      });
+
+      // Should return null instead of throwing
+      expect(result).toBeNull();
+    });
+
+    it('should default metadata to empty object', async () => {
+      prisma.auditLog.create.mockResolvedValue({ id: '1' });
+
+      await service.recordAction({
+        userId: 'user-1',
+        action: 'USER_LOGIN',
+      });
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            metadata: {},
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('getLogs', () => {
+    it('should return paginated audit logs', async () => {
+      const mockLogs = [
+        { id: '1', action: 'BOUNTY_DELETE' },
+        { id: '2', action: 'USER_BAN' },
+      ];
+
+      prisma.auditLog.findMany.mockResolvedValue(mockLogs);
+      prisma.auditLog.count.mockResolvedValue(2);
+
+      const result = await service.getLogs({ page: 0, size: 10 });
+
+      expect(result.items).toEqual(mockLogs);
+      expect(result.total).toBe(2);
+      expect(result.page).toBe(0);
+      expect(result.size).toBe(10);
+    });
+  });
+});

--- a/backend/src/audit/audit.service.ts
+++ b/backend/src/audit/audit.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+export interface AuditLogRecord {
+  userId: string;
+  action: string;
+  entityType?: string;
+  entityId?: string;
+  metadata?: Record<string, any>;
+}
+
+@Injectable()
+export class AuditService {
+  private readonly logger = new Logger(AuditService.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  async recordAction(record: AuditLogRecord) {
+    try {
+      const logEntry = await this.prisma.auditLog.create({
+        data: {
+          userId: record.userId,
+          action: record.action,
+          entityType: record.entityType,
+          entityId: record.entityId,
+          metadata: record.metadata || {},
+        },
+      });
+
+      this.logger.debug(
+        `Audit logged: ${record.action} on ${record.entityType}/${record.entityId} by user ${record.userId}`,
+      );
+
+      return logEntry;
+    } catch (err: any) {
+      // Don't throw — audit logging should not break business flows
+      this.logger.error(`Failed to write audit log: ${err.message}`);
+      return null;
+    }
+  }
+
+  async getLogs(filters?: {
+    userId?: string;
+    action?: string;
+    entityType?: string;
+    page?: number;
+    size?: number;
+  }) {
+    const page = filters?.page ?? 0;
+    const size = filters?.size ?? 50;
+
+    const where: any = {};
+    if (filters?.userId) where.userId = filters.userId;
+    if (filters?.action) where.action = { contains: filters.action, mode: 'insensitive' };
+    if (filters?.entityType) where.entityType = filters.entityType;
+
+    const [items, total] = await Promise.all([
+      this.prisma.auditLog.findMany({
+        where,
+        skip: page * size,
+        take: size,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.auditLog.count({ where }),
+    ]);
+
+    return { items, total, page, size };
+  }
+}

--- a/backend/src/audit/log-audit.decorator.ts
+++ b/backend/src/audit/log-audit.decorator.ts
@@ -1,0 +1,9 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const AUDIT_ACTION_KEY = 'audit_action';
+
+/**
+ * Decorator to mark a controller method for audit logging.
+ * Usage: @LogAudit('BOUNTY_DELETE') or @LogAudit('USER_BAN')
+ */
+export const LogAudit = (action: string) => SetMetadata(AUDIT_ACTION_KEY, action);


### PR DESCRIPTION
Fixes #248

## Changes
- **Prisma Schema**: Added `AuditLog` model with fields: `userId`, `action`, `entityType`, `entityId`, `metadata` (JSON)
- **AuditService**: 
  - `recordAction()` — writes audit entry to DB, catches errors gracefully (never breaks business flows)
  - `getLogs()` — paginated query with filters (userId, action, entityType)
- **@LogAudit('action_name')** decorator — apply to any controller method to mark it for auditing
- **AuditLogInterceptor** — auto-logs decorated endpoints after successful execution; extracts entity type/id from route params
- **AuditModule** — exports service + interceptor for use in other modules via imports
- **Unit Tests** — 4 tests covering: successful recording, DB error handling, default metadata, paginated retrieval

## Acceptance Criteria Met
- [x] Add an `AuditLog` model to Prisma (fields: userId, action, entityType, entityId, metadata JSON)
- [x] Develop a standard `AuditService` with a `recordAction()` method
- [x] Create an explicit Unit test isolating the service — mocking an action ('BOUNTY_DELETE') and verifying it drops a record

## How to Verify
1. Run `npx prisma migrate dev --name add_audit_log`
2. Import `AuditModule` into any feature module that needs auditing
3. Apply `@LogAudit('BOUNTY_DELETE')` to a controller method + bind `AuditLogInterceptor`
4. Call that endpoint → check `audit_logs` table for new entries