### PR TITLE
[Backend] Role-Based Control Guards for Route Scopes

### DIFF
--- a/backend/src/bounty/bounty.controller.ts
+++ b/backend/src/bounty/bounty.controller.ts
@@ -11,6 +11,9 @@ import {
   Delete,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RoleGuard } from '../auth/guards/role.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../user/dto/user.dto';
 import { BountyService } from './bounty.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
 import { UpdateBountyDto } from './dto/update-bounty.dto';
@@ -50,7 +53,8 @@ export class BountyController {
     return this.service.search(q, Number(page), Number(size), guildId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN)
   @Patch(':id')
   async update(
     @Param('id') id: string,
@@ -60,7 +64,8 @@ export class BountyController {
     return this.service.update(id, dto, req.user.userId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN)
   @Post(':id/cancel')
   async cancel(@Param('id') id: string, @Request() req: any) {
     return this.service.cancel(id, req.user.userId);
@@ -82,7 +87,8 @@ export class BountyController {
     return this.service.listApplications(id, req.user.userId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN, UserRole.MODERATOR)
   @Post(':id/applications/:appId/review')
   async reviewApplication(
     @Param('id') id: string,
@@ -120,7 +126,8 @@ export class BountyController {
     return this.service.completeMilestone(id, mid, req.user.userId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN, UserRole.MODERATOR)
   @Post(':id/milestones/:mid/approve')
   async approveMilestone(
     @Param('id') id: string,
@@ -148,7 +155,8 @@ export class BountyController {
    * Admin endpoint to review submitted bounty work
    * POST /bounties/:id/review-work
    */
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(UserRole.ADMIN)
   @Post(':id/review-work')
   async reviewWork(
     @Param('id') id: string,


### PR DESCRIPTION
Fixes #296

## Changes
- **BountyController**: Applied `RoleGuard` + `@Roles(...)` to all mutating endpoints:
  - `PATCH /bounties/:id` (update) → **ADMIN only**
  - `POST /bounties/:id/cancel` → **ADMIN only**
  - `POST /bounties/:id/review-work` → **ADMIN only**
  - `POST /bounties/:id/applications/:appId/review` → **ADMIN or MODERATOR**
  - `POST /bounties/:id/milestones/:mid/approve` → **ADMIN or MODERATOR**
- Non-admin/moderator users receive standard NestJS `403 Forbidden` response
- Read endpoints (GET, create, apply, submit-work) remain open to any authenticated user

## Acceptance Criteria Met
- [x] Develop `@Roles(...roles)` decorator assigning acceptable criteria array strings (already existed — now applied)
- [x] Develop `RolesGuard` examining ExecutionCtx payload reflecting User roles (already existed — now applied)
- [x] Add explicit block restricting `/bounties/:id` mutating patches exclusively to ADMIN (and MODERATOR for review endpoints)
- [x] Expose standard 403 Forbidden exception payload

## How to Verify
1. Register two users: one as USER, one as ADMIN
2. Call `PATCH /bounties/:id` with USER token → 403 Forbidden
3. Call `PATCH /bounties/:id` with ADMIN token → success
4. Same pattern applies to cancel, review-work, approve milestones