### PR TITLE
feat(backend): role-based control guards for route scopes

### DIFF
--- a/backend/src/bounty/bounty.controller.ts
+++ b/backend/src/bounty/bounty.controller.ts
@@ -11,6 +11,8 @@ import {
   Delete,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
 import { BountyService } from './bounty.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
 import { UpdateBountyDto } from './dto/update-bounty.dto';
@@ -50,7 +52,8 @@ export class BountyController {
     return this.service.search(q, Number(page), Number(size), guildId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
   @Patch(':id')
   async update(
     @Param('id') id: string,

--- a/backend/src/common/decorators/roles.decorator.ts
+++ b/backend/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RolesGuard } from './roles.guard';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+
+function createMockContext(user?: any): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+  } as unknown as ExecutionContext;
+}
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RolesGuard, Reflector],
+    }).compile();
+
+    guard = module.get<RolesGuard>(RolesGuard);
+    reflector = module.get<Reflector>(Reflector);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('should allow when no roles required', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+    expect(await guard.canActivate(createMockContext({ userId: '1' }))).toBe(true);
+  });
+
+  it('should throw when no user authenticated', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['ADMIN']);
+    await expect(guard.canActivate(createMockContext(undefined))).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('should allow when user has required role', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['ADMIN']);
+    expect(
+      await guard.canActivate(createMockContext({ userId: '1', roles: ['ADMIN'] })),
+    ).toBe(true);
+  });
+
+  it('should deny when user lacks required role', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['ADMIN']);
+    await expect(
+      guard.canActivate(createMockContext({ userId: '1', roles: ['USER'] })),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -1,0 +1,50 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles =
+      this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]);
+
+    // No roles required → allow
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+
+    if (!user) {
+      throw new ForbiddenException('Authentication required');
+    }
+
+    // Check if user has any of the required roles
+    // Supports both string[] and comma-separated string
+    const userRoles = Array.isArray(user.roles)
+      ? user.roles
+      : (user.roles?.split(',').map((r: string) => r.trim()) ?? []);
+
+    const hasRole = requiredRoles.some((role) =>
+      userRoles.includes(role),
+    );
+
+    if (!hasRole) {
+      throw new ForbiddenException(
+        `Insufficient permissions. Required role(s): ${requiredRoles.join(', ')}`,
+      );
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
Fixes #296

## Summary
Implemented role-based access control (RBAC) guards for NestJS routes, with `@Roles()` decorator and `RolesGuard`. Applied to restrict bounty mutation endpoints to ADMIN users.

## Changes

### New Files
- **`backend/src/common/decorators/roles.decorator.ts`** — `@Roles(...roles)` metadata decorator
- **`backend/src/common/guards/roles.guard.ts`** — `RolesGuard` that:
  - Reads required roles from handler/class metadata via Reflector
  - Checks `user.roles` (supports `string[]` or comma-separated string)
  - Allows access if user has **any** of the required roles
  - Returns `403 Forbidden` with descriptive message on denial
  - Passes through when no roles are required
- **`backend/src/common/guards/roles.guard.spec.ts`** — Unit tests (4 cases)

### Modified
- **`backend/src/bounty/bounty.controller.ts`** — Added `RolesGuard` + `@Roles(ADMIN)` to `PATCH /bounties/:id`

## Usage
```typescript
// Single role
@UseGuards(JwtAuthGuard, RolesGuard)
@Roles(ADMIN)
@Patch(:id)
async update(...) { }

// Multiple roles (user needs at least one)
@Roles(ADMIN, MODERATOR)
```

## Verification
```bash
# Run guard tests
cd backend && npm test -- common/guards/roles.guard.spec.ts

# Manual test:
# PATCH /bounties/1 with user.role=USER → 403 Forbidden
# PATCH /bounties/1 with user.role=ADMIN → 200 OK
```