### PR TITLE
feat(backend): implement environment config validation guard

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
+import { configValidationSchema } from './common/config/config.validation';
 import { PrismaModule } from './prisma/prisma.module';
 import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
@@ -18,6 +19,12 @@ import { QueueModule } from './queue/queue.module';
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
+      validationSchema: configValidationSchema,
+      validationOptions: {
+        abortEarly: false,        // report all errors at once
+        allowUnknown: true,       // allow extra env vars
+        stripUnknown: false,      // keep unknown vars
+      },
     }),
     ThrottlerModule.forRoot([
       {

--- a/backend/src/common/config/config.validation.ts
+++ b/backend/src/common/config/config.validation.ts
@@ -1,0 +1,66 @@
+/**
+ * Environment configuration validation schema using Joi.
+ *
+ * Required env vars: PORT, DATABASE_URL, JWT_SECRET
+ * Conditional: REDIS_URL (required unless QUEUE_DISABLED=true)
+ *
+ * Usage: import in AppModule and pass to ConfigModule.forRoot({ validationSchema })
+ *
+ * Install: npm install joi
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Joi = require('joi');
+
+export const configValidationSchema = Joi.object({
+  // Server
+  PORT: Joi.number().default(3000).optional(),
+  NODE_ENV: Joi.string()
+    .valid('development', 'production', 'test')
+    .default('development'),
+
+  // Database (required)
+  DATABASE_URL: Joi.string().required().messages({
+    'any.required': 'Missing Configuration: DATABASE_URL',
+    'string.empty': 'Missing Configuration: DATABASE_URL',
+  }),
+
+  // Auth (required)
+  JWT_SECRET: Joi.string().min(16).required().messages({
+    'any.required': 'Missing Configuration: JWT_SECRET',
+    'string.empty': 'Missing Configuration: JWT_SECRET',
+    'string.min': 'JWT_SECRET must be at least 16 characters',
+  }),
+  JWT_EXPIRES_IN: Joi.string().default('1d').optional(),
+
+  // Redis / Queue (required unless queue disabled)
+  REDIS_URL: Joi.when('QUEUE_DISABLED', {
+    is: Joi.exist().valid('true', '1', 'true'),
+    then: Joi.string().optional(),
+    otherwise: Joi.string().required().messages({
+      'any.required': 'Missing Configuration: REDIS_URL (required when queue is enabled)',
+    }),
+  }),
+  QUEUE_DISABLED: Joi.string()
+    .valid('true', '1', 'false', '0')
+    .optional(),
+
+  // Storage
+  STORAGE_PROVIDER: Joi.string()
+    .valid('local', 's3', 'ipfs')
+    .default('local')
+    .optional(),
+  STORAGE_LOCAL_DIR: Joi.string().optional(),
+  AWS_ACCESS_KEY_ID: Joi.string().optional(),
+  AWS_SECRET_ACCESS_KEY: Joi.string().optional(),
+  AWS_S3_BUCKET: Joi.string().optional(),
+  AWS_REGION: Joi.string().optional(),
+
+  // Mail
+  SMTP_HOST: Joi.string().optional(),
+  SMTP_PORT: Joi.number().optional(),
+  SMTP_USER: Joi.string().optional(),
+  SMTP_PASS: Joi.string().optional(),
+
+  // App
+  FRONTEND_URL: Joi.string().optional(),
+});


### PR DESCRIPTION
Fixes #292

## Summary
Added Joi-based environment configuration validation to NestJS `ConfigModule`. The app now fails fast at startup with clear error messages if required environment variables are missing.

## Changes
- **`backend/src/common/config/config.validation.ts`** — New Joi validation schema:
  - **Required**: `DATABASE_URL`, `JWT_SECRET` (min 16 chars)
  - **Conditional**: `REDIS_URL` (required unless `QUEUE_DISABLED=true`)
  - **Optional with defaults**: `PORT`, `NODE_ENV`, `STORAGE_PROVIDER`, etc.
  - Custom error messages: `"Missing Configuration: XYZ"`
  - Supports storage (local/S3/IPFS), mail (SMTP), and app config

- **`backend/src/app.module.ts`** — Updated `ConfigModule.forRoot()`:
  - Added `validationSchema: configValidationSchema`
  - `abortEarly: false` — reports all errors at once
  - Missing vars → clear console error + `process.exit(1)` (NestJS default behavior)

## Prerequisites
```bash
cd backend && npm install joi
```

## Verification
```bash
# Test 1: Missing required var → crash on startup
unset DATABASE_URL && npm run start
# → Error: "Missing Configuration: DATABASE_URL"

# Test 2: Invalid JWT_SECRET → crash
export JWT_SECRET="short"
npm run start
# → Error: "JWT_SECRET must be at least 16 characters"

# Test 3: All valid → starts normally
export DATABASE_URL="postgresql://..." JWT_SECRET="my-super-secret-key-12345"
npm run start
# → ✅ Server listening on port 3000
```