### PR TITLE
feat(frontend): generic sortable data table component

### DIFF
--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import React, { useMemo, useState } from 'react'
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  flexRender,
+  createColumnHelper,
+  SortingState,
+} from '@tanstack/react-table'
+import { cn } from '@/lib/utils'
+import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
+
+/* ---------- types ---------- */
+
+type ColumnKey = string
+
+interface DataTableProps<T extends Record<string, unknown>> {
+  data: T[]
+  columns: {
+    accessorKey: ColumnKey
+    header: string
+    cell?: (value: unknown, row: T) => React.ReactNode
+    sortable?: boolean
+  }[]
+  /** Message shown when data is empty */
+  emptyMessage?: string
+  /** Enable row stripe coloring */
+  striped?: boolean
+  className?: string
+}
+
+/* ---------- component ---------- */
+
+export function DataTable<T extends Record<string, unknown>>({
+  data,
+  columns: columnDefs,
+  emptyMessage = 'No data available',
+  striped = true,
+  className,
+}: DataTableProps<T>) {
+  const [sorting, setSorting] = useState<SortingState>([])
+
+  // Build tanstack columns from simple def array
+  const columns = useMemo(() => {
+    return columnDefs.map((col) =>
+      createColumnHelper<T>().accessor(col.accessorKey as keyof T, {
+        header: () => (
+          <div className="flex items-center gap-1.5">
+            <span>{col.header}</span>
+            {col.sortable !== false && (
+              <SortIndicator />
+            )}
+          </div>
+        ),
+        cell: (info) => {
+          if (col.cell) return col.cell(info.getValue(), info.row.original)
+          return (info.getValue() as React.ReactNode) ?? '—'
+        },
+      })
+    )
+  }, [columnDefs])
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  })
+
+  if (!data || data.length === 0) {
+    return (
+      <div className={cn(
+        'rounded-xl border border-stellar-lightNavy bg-stellar-lightNavy/30',
+        'flex items-center justify-center py-16 text-sm text-stellar-slate',
+        className
+      )}>
+        {emptyMessage}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('overflow-x-auto rounded-xl border border-stellar-lightNavy', className)}>
+      <table className="w-full text-left text-sm">
+        {/* Header */}
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th
+                  key={header.id}
+                  onClick={header.column.getToggleSortingHandler()}
+                  className={cn(
+                    'whitespace-nowrap px-4 py-3 font-medium text-stellar-slate border-b border-stellar-lightNavy',
+                    header.column.getCanSort() && 'cursor-pointer select-none hover:text-stellar-white transition-colors'
+                  )}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+
+        {/* Body */}
+        <tbody>
+          {table.getRowModel().rows.map((row, idx) => (
+            <tr
+              key={row.id}
+              className={cn(
+                'border-b border-stellar-lightNavy/50 transition-colors hover:bg-stellar-lightNavy/20',
+                striped && idx % 2 === 1 && 'bg-stellar-lightNavy/10'
+              )}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id} className="px-4 py-3 text-stellar-white/90">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+/* ---------- internal: sort indicator ---------- */
+
+function SortIndicator() {
+  const { column } = (() => ({ column: null }))()
+  // We rely on the table context for actual sort direction;
+  // this is a static icon that the parent header toggles.
+  return (
+    <span className="inline-flex">
+      <ArrowUpDown className="h-3 w-3 opacity-40" />
+    </span>
+  )
+}
+
+export default DataTable

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -14,3 +14,4 @@ export {
   DropdownMenuItem,
 } from "./DropdownMenu";
 export { Pagination } from "./Pagination";
+export { DataTable } from "./DataTable";


### PR DESCRIPTION
Fixes #273

## Summary
Built a generic, reusable `DataTable` component powered by `@tanstack/react-table` v8 with column sorting, empty state handling, and dark glassmorphism styling.

## Changes
- **`frontend/src/components/ui/DataTable.tsx`** — New component:
  - **Generic type**: `DataTable<T>` works with any `Record<string, unknown>` data
  - **Sorting**: Click any column header to toggle asc/desc (uses `getSortedRowModel`)
  - **Empty state**: Shows customizable "No data available" message when data is empty
  - **Dark theme**: Glassmorphism styling matching the app's design system
    - Rounded borders, subtle backgrounds, hover effects
    - Row striping for readability
  - **Responsive**: Horizontal scroll on overflow (`overflow-x-auto`)
  - **Simple API**:
    ```tsx
    <DataTable
      data={users}
      columns={[
        { accessorKey: 'name', header: 'Name' },
        { accessorKey: 'role', header: 'Role' },
        { accessorKey: 'email', header: 'Email', cell: (v) => <a>{v}</a> },
      ]}
    />
    ```
- **`frontend/src/components/ui/index.ts`** — Exports `DataTable`

## Prerequisites
```bash
cd frontend && npm install @tanstack/react-table
```

## Verification
1. Render `<DataTable data={[]} columns={...} />` → shows empty state message
2. Render with data → table displays with sortable headers
3. Click column header → sorts asc, click again → sorts desc
4. Resize browser → horizontal scroll on small screens
5. Alternating row colors visible when `striped={true}` (default)
