### PR TITLE
Implement soft delete for bounties (Closes #235)

### DIFF
--- a/backend/src/bounty/bounty.controller.ts
+++ b/backend/src/bounty/bounty.controller.ts
@@ -157,4 +157,15 @@ export class BountyController {
   ) {
     return this.service.reviewWork(id, dto, req.user.userId);
   }
+
+  /**
+   * Soft delete a bounty
+   * DELETE /bounties/:id
+   */
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id')
+  async remove(@Param('id') id: string, @Request() req: any) {
+    return this.service.remove(id, req.user.userId);
+  }
+
 }

--- a/backend/src/bounty/bounty.service.ts
+++ b/backend/src/bounty/bounty.service.ts
@@ -35,7 +35,7 @@ export class BountyService {
 
   async findOne(id: string) {
     const bounty = await this.prisma.bounty.findUnique({
-      where: { id },
+      where: { id, deletedAt: null },
       include: {
         creator: true,
         assignee: true,
@@ -47,7 +47,7 @@ export class BountyService {
 
   async get(id: string) {
     const bounty = await this.prisma.bounty.findUnique({
-      where: { id },
+      where: { id, deletedAt: null },
       include: { creator: true, assignee: true },
     });
     if (!bounty) throw new NotFoundException('Bounty not found');
@@ -65,7 +65,7 @@ export class BountyService {
     const page = filters.page ?? 0;
     const size = filters.size ?? 20;
 
-    const where: any = {};
+    const where: any = { deletedAt: null };
 
     // Default to OPEN status if no status filter provided
     if (filters.status) {
@@ -108,7 +108,7 @@ export class BountyService {
         }
       : {};
 
-    const where: any = {};
+    const where: any = { deletedAt: null };
     if (Object.keys(text).length) where.AND = [text];
     if (guildId) where.guildId = guildId;
 
@@ -522,4 +522,23 @@ export class BountyService {
       };
     }
   }
+
+  /**
+   * Soft delete a bounty (sets deletedAt timestamp)
+   * Only the creator can delete their own bounty
+   */
+  async remove(id: string, userId: string) {
+    const bounty = await this.prisma.bounty.findUnique({
+      where: { id, deletedAt: null },
+    });
+    if (!bounty) throw new NotFoundException('Bounty not found');
+    if (bounty.creatorId !== userId)
+      throw new ForbiddenException('Only creator can delete bounty');
+
+    return this.prisma.bounty.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
 }


### PR DESCRIPTION
Hey! 👋

I saw the issue about soft deleting bounties and thought I'd take a crack at it.

**What I changed:**

In `bounty.service.ts`:
- Added `deletedAt: null` filter to `findOne`, `get`, `findAll`, and `search` queries so deleted bounties never show up in listings
- Added a `remove()` method that sets `deletedAt = new Date()` instead of doing a hard delete

In `bounty.controller.ts`:
- Added `DELETE /bounties/:id` endpoint that calls the new `remove()` method
- Requires JWT auth and only the creator can delete their own bounty

The schema already had the `deletedAt` field on the Bounty model, so I just had to wire up the filtering and the soft delete logic.

Let me know if you'd like any changes! Happy to tweak the approach.
