### PR TITLE
feat: enforce Content-Type: application/json on write requests (closes #433)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,8 @@ import { APP_GUARD } from '@nestjs/core';
 import { HealthModule } from './health/health.module';
 import { LoggerModule } from './logger/logger.module';
 import { QueueModule } from './queue/queue.module';
+import { ContentTypeMiddleware } from './common/middleware/content-type.middleware';
+import { MiddlewareConsumer, NestModule } from '@nestjs/common';
 
 @Module({
   imports: [
@@ -44,4 +46,8 @@ import { QueueModule } from './queue/queue.module';
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(ContentTypeMiddleware).forRoutes('*');
+  }
+}

--- a/backend/src/common/middleware/content-type.middleware.ts
+++ b/backend/src/common/middleware/content-type.middleware.ts
@@ -1,0 +1,44 @@
+import { Injectable, NestMiddleware, UnsupportedMediaTypeException } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+const ALLOWED_CONTENT_TYPES = [
+  'application/json',
+  'multipart/form-data',
+];
+
+/**
+ * Middleware that enforces Content-Type header on write requests.
+ *
+ * - POST/PUT/PATCH must declare Content-Type: application/json or multipart/form-data
+ * - GET, DELETE, HEAD, OPTIONS are exempt
+ * - multipart/form-data is allowed for file upload routes
+ */
+@Injectable()
+export class ContentTypeMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction) {
+    if (!WRITE_METHODS.has(req.method)) {
+      return next();
+    }
+
+    const contentType = req.headers['content-type'];
+
+    if (!contentType) {
+      throw new UnsupportedMediaTypeException(
+        'Content-Type header is required for write operations. Expected: application/json',
+      );
+    }
+
+    const isAllowed = ALLOWED_CONTENT_TYPES.some((allowed) =>
+      contentType.toLowerCase().startsWith(allowed),
+    );
+
+    if (!isAllowed) {
+      throw new UnsupportedMediaTypeException(
+        `Unsupported Content-Type: ${contentType}. Expected: application/json`,
+      );
+    }
+
+    next();
+  }
+}


### PR DESCRIPTION
Hey! I went ahead and tackled issue #433 — Content-Type enforcement for write operations.

Here's the approach I took:

**Middleware** (`backend/src/common/middleware/content-type.middleware.ts`): Created a NestJS middleware that checks the `Content-Type` header on POST, PUT, and PATCH requests. If it's missing or not `application/json` (or `multipart/form-data` for uploads), it throws a `415 Unsupported Media Type` exception. GET, DELETE, HEAD, and OPTIONS are left alone.

**Registration** (`backend/src/app.module.ts`): Implemented `NestModule` on `AppModule` and registered the middleware for all routes via `consumer.apply(ContentTypeMiddleware).forRoutes('*')`.

I allowed `multipart/form-data` since the avatar upload route uses it, and it didn't make sense to block that. Let me know if you'd prefer a different approach or want to scope it differently!