### PR TITLE
feat: add User Favorite Guilds feature (closes #430)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -94,6 +94,7 @@ model User {
   privacySettings    PrivacySettings?
   bountyApplications BountyApplication[]
   bountyPayouts      BountyPayout[]
+  favoriteGuilds     UserFavoriteGuild[]
 
   @@map("users")
 }
@@ -117,6 +118,7 @@ model Guild {
   owner       User              @relation("UserOwnerGuilds", fields: [ownerId], references: [id])
   memberships GuildMembership[]
   bounties    Bounty[]          @relation("GuildBounties")
+  favoritedBy UserFavoriteGuild[]
 
   @@map("guilds")
 }
@@ -291,4 +293,17 @@ model PrivacySettings {
   showActivityFeed              Boolean @default(true)
   allowMessagesFromNonFollowers Boolean @default(false)
   showAchievements              Boolean @default(true)
+}
+
+model UserFavoriteGuild {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  userId    String
+  guildId   String
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, guildId])
+  @@map("user_favorite_guilds")
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -165,6 +165,71 @@ export class UserController {
   }
 
   /**
+   * Get current user's favorite guilds
+   */
+  @Get('me/favorites')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get current user\'s favorite guilds' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'List of favorite guilds',
+  })
+  async getFavoriteGuilds(@Request() req: any) {
+    return this.userService.getFavoriteGuilds(req.user.userId);
+  }
+
+  /**
+   * Add a guild to current user's favorites
+   */
+  @Post('me/favorites/:guildId')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Add a guild to favorites' })
+  @ApiParam({ name: 'guildId', description: 'Guild ID to favorite' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Guild added to favorites',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Guild not found',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Guild already in favorites',
+  })
+  async addFavoriteGuild(
+    @Request() req: any,
+    @Param('guildId') guildId: string,
+  ) {
+    return this.userService.addFavoriteGuild(req.user.userId, guildId);
+  }
+
+  /**
+   * Remove a guild from current user's favorites
+   */
+  @Delete('me/favorites/:guildId')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Remove a guild from favorites' })
+  @ApiParam({ name: 'guildId', description: 'Guild ID to unfavorite' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Guild removed from favorites',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Guild not in favorites',
+  })
+  async removeFavoriteGuild(
+    @Request() req: any,
+    @Param('guildId') guildId: string,
+  ) {
+    return this.userService.removeFavoriteGuild(req.user.userId, guildId);
+  }
+
+  /**
    * Get user details (admin or self)
    */
   @Get('details/:userId')

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -448,4 +448,95 @@ export class UserService {
       where,
     });
   }
+
+  /**
+   * Get current user's favorite guilds
+   */
+  async getFavoriteGuilds(userId: string) {
+    const favorites = await this.prisma.userFavoriteGuild.findMany({
+      where: { userId },
+      include: {
+        guild: {
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+            description: true,
+            avatarUrl: true,
+            bannerUrl: true,
+            memberCount: true,
+            _count: { select: { bounties: true } },
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return {
+      data: favorites.map((f) => ({
+        favoritedAt: f.createdAt,
+        ...f.guild,
+        bountyCount: f.guild._count.bounties,
+      })),
+      total: favorites.length,
+    };
+  }
+
+  /**
+   * Add a guild to user's favorites
+   */
+  async addFavoriteGuild(userId: string, guildId: string) {
+    // Verify the guild exists
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+    });
+    if (!guild) {
+      throw new NotFoundException('Guild not found');
+    }
+
+    // Check if already favorited (unique constraint will also catch this, but we can give a nicer error)
+    const existing = await this.prisma.userFavoriteGuild.findUnique({
+      where: { userId_guildId: { userId, guildId } },
+    });
+    if (existing) {
+      throw new BadRequestException('Guild is already in your favorites');
+    }
+
+    const favorite = await this.prisma.userFavoriteGuild.create({
+      data: { userId, guildId },
+      include: {
+        guild: {
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+            avatarUrl: true,
+          },
+        },
+      },
+    });
+
+    return {
+      message: 'Guild added to favorites',
+      favorite,
+    };
+  }
+
+  /**
+   * Remove a guild from user's favorites
+   */
+  async removeFavoriteGuild(userId: string, guildId: string) {
+    const existing = await this.prisma.userFavoriteGuild.findUnique({
+      where: { userId_guildId: { userId, guildId } },
+    });
+    if (!existing) {
+      throw new NotFoundException('Guild is not in your favorites');
+    }
+
+    await this.prisma.userFavoriteGuild.delete({
+      where: { userId_guildId: { userId, guildId } },
+    });
+
+    return { message: 'Guild removed from favorites' };
+  }
 }


### PR DESCRIPTION
Hey! I noticed issue #430 about adding a favorite guilds feature, so I went ahead and built it out.

Here's what I did:

**Schema**: Added a `UserFavoriteGuild` model with `userId` + `guildId` as a unique pair, so the same user can't accidentally favorite the same guild twice. The `@@unique` constraint handles the dedup at the database level, and I also added a friendlier error message in the service layer.

**Endpoints**:
- `GET /users/me/favorites` — returns the user's favorited guilds with some useful metadata (member count, bounty count, etc.)
- `POST /users/me/favorites/:guildId` — adds a guild to favorites, checks if the guild exists first
- `DELETE /users/me/favorites/:guildId` — removes a guild from favorites

All three are behind `JwtAuthGuard` so only authenticated users can manage their favorites. I followed the same patterns I saw in the rest of the user module — consistent select clauses, proper error codes (404 for missing guild, 400 for duplicates), and the same NestJS decorator style.

The Prisma relations are set up with `onDelete: Cascade` on both sides, so if a user or guild gets deleted, the favorite records clean up automatically.

Would love your feedback on this! Happy to adjust the response shape or add any extra validation if needed.