### PR TITLE
feat: automated bounty reminder system (#399)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.12",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.2.5",
         "@nestjs/terminus": "^11.1.1",
         "@nestjs/throttler": "^6.5.0",
@@ -2467,6 +2468,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.9",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
@@ -3172,6 +3186,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -5292,6 +5312,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.12",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.2.5",
     "@nestjs/terminus": "^11.1.1",
     "@nestjs/throttler": "^6.5.0",
@@ -89,7 +90,9 @@
       "ts"
     ],
     "rootDir": "src",
-    "setupFiles": ["dotenv/config"],
+    "setupFiles": [
+      "dotenv/config"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/backend/prisma/migrations/20250416160000_add_reminder_sent/migration.sql
+++ b/backend/prisma/migrations/20250416160000_add_reminder_sent/migration.sql
@@ -1,0 +1,11 @@
+-- Add reminderSent column to bounties table
+-- This column tracks whether a reminder email has been sent for a bounty nearing expiration
+
+ALTER TABLE "bounties"
+ADD COLUMN IF NOT EXISTS "reminderSent" BOOLEAN NOT NULL DEFAULT false;
+
+-- Create an index for efficient querying of bounties needing reminders
+CREATE INDEX IF NOT EXISTS "bounties_reminder_sent_idx" ON "bounties"("reminderSent");
+
+-- Create an index for deadline queries combined with status
+CREATE INDEX IF NOT EXISTS "bounties_deadline_status_idx" ON "bounties"("deadline", "status");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -164,6 +164,7 @@ model Bounty {
   creatorId    String
   assigneeId   String?
   guildId      String?
+  reminderSent Boolean   @default(false)
 
   // Relations
   creator      User                @relation("UserCreatedBounties", fields: [creatorId], references: [id])

--- a/backend/src/bounty/bounty-reminder.service.ts
+++ b/backend/src/bounty/bounty-reminder.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service';
+import { MailerService } from '../mailer/mailer.service';
+
+/**
+ * Service responsible for sending automated reminders for bounties nearing expiration.
+ * Runs every 6 hours to check for OPEN bounties expiring within 20-26 hours.
+ */
+@Injectable()
+export class BountyReminderService {
+  private readonly logger = new Logger(BountyReminderService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly mailer: MailerService,
+  ) {}
+
+  /**
+   * Cron job that runs every 6 hours to check for expiring bounties
+   * and send reminder emails to guild admins/creators.
+   */
+  @Cron('0 */6 * * *')
+  async handleBountyReminders(): Promise<void> {
+    const now = new Date();
+    const twentyHoursFromNow = new Date(now.getTime() + 20 * 60 * 60 * 1000);
+    const twentySixHoursFromNow = new Date(now.getTime() + 26 * 60 * 60 * 1000);
+
+    this.logger.log('Checking for expiring bounties...');
+    this.logger.debug(`Time window: ${twentyHoursFromNow.toISOString()} to ${twentySixHoursFromNow.toISOString()}`);
+
+    try {
+      const expiringBounties = await this.prisma.bounty.findMany({
+        where: {
+          status: 'OPEN',
+          reminderSent: false,
+          deadline: {
+            gte: twentyHoursFromNow,
+            lte: twentySixHoursFromNow,
+          },
+        },
+        include: {
+          guild: {
+            include: {
+              owner: true,
+            },
+          },
+          creator: true,
+        },
+      });
+
+      this.logger.log(`Found ${expiringBounties.length} bounties nearing expiration`);
+
+      for (const bounty of expiringBounties) {
+        await this.processBountyReminder(bounty);
+      }
+    } catch (error) {
+      this.logger.error('Error processing bounty reminders:', error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  /**
+   * Process a single bounty reminder - send email and mark as reminded
+   */
+  private async processBountyReminder(bounty: {
+    id: string;
+    title: string;
+    deadline: Date | null;
+    guild: { owner: { email: string } | null } | null;
+    creator: { email: string } | null;
+  }): Promise<void> {
+    // Determine admin email: guild owner first, then creator
+    const adminEmail = bounty.guild?.owner?.email || bounty.creator?.email;
+
+    if (!adminEmail) {
+      this.logger.warn(`No admin email found for bounty ${bounty.id}`);
+      return;
+    }
+
+    if (!bounty.deadline) {
+      this.logger.warn(`Bounty ${bounty.id} has no deadline, skipping reminder`);
+      return;
+    }
+
+    try {
+      await this.mailer.sendBountyReminderEmail(
+        adminEmail,
+        bounty.title,
+        bounty.deadline,
+        bounty.id,
+      );
+
+      // Mark bounty as reminded to prevent duplicate emails
+      await this.prisma.bounty.update({
+        where: { id: bounty.id },
+        data: { reminderSent: true },
+      });
+
+      this.logger.log(`Reminder sent for bounty ${bounty.id} to ${adminEmail}`);
+    } catch (error) {
+      this.logger.error(
+        `Failed to send reminder for bounty ${bounty.id}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+}

--- a/backend/src/bounty/bounty.module.ts
+++ b/backend/src/bounty/bounty.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { BountyService } from './bounty.service';
 import { BountyController } from './bounty.controller';
+import { BountyReminderService } from './bounty-reminder.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { MailerModule } from '../mailer/mailer.module';
 
 @Module({
-  imports: [PrismaModule, MailerModule],
-  providers: [BountyService],
+  imports: [ScheduleModule.forRoot(), PrismaModule, MailerModule],
+  providers: [BountyService, BountyReminderService],
   controllers: [BountyController],
   exports: [BountyService],
 })

--- a/backend/src/mailer/mailer.service.ts
+++ b/backend/src/mailer/mailer.service.ts
@@ -70,4 +70,54 @@ If you weren't expecting this invite, ignore this message.`;
       this.logger.log(`Revoke (not sent) -> to: ${to}, subject: ${subject}`);
     }
   }
+
+  /**
+   * Send a reminder email for a bounty nearing expiration.
+   * @param to - Recipient email address
+   * @param bountyTitle - Title of the bounty
+   * @param deadline - Expiration date/time of the bounty
+   * @param bountyId - Unique identifier for the bounty
+   */
+  async sendBountyReminderEmail(
+    to: string,
+    bountyTitle: string,
+    deadline: Date,
+    bountyId: string,
+  ): Promise<void> {
+    const from =
+      process.env.MAIL_FROM ||
+      process.env.SMTP_USER ||
+      'no-reply@stellar-guilds.local';
+
+    const formattedDeadline = deadline.toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    });
+
+    const subject = `Reminder: Bounty "${bountyTitle}" expires in 24 hours`;
+    const text = `Hello,
+
+This is a reminder that your bounty "${bountyTitle}" is set to expire on ${formattedDeadline}.
+
+If you need to extend the deadline or review current submissions, please visit your guild dashboard before the bounty expires.
+
+Bounty ID: ${bountyId}
+
+Best regards,
+Stellar Guilds Team`;
+
+    if (this.transporter) {
+      await this.transporter.sendMail({ from, to, subject, text });
+      this.logger.log(`Bounty reminder sent to ${to} for bounty ${bountyId}`);
+    } else {
+      this.logger.log(
+        `Bounty reminder (not sent) -> to: ${to}, bounty: "${bountyTitle}", deadline: ${formattedDeadline}`,
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary

This PR implements the automated bounty reminder system requested in #399.

### Changes

1. **Database Schema**
   - Added `reminderSent` boolean field to `bounties` table
   - Created migration with indexes for efficient querying

2. **BountyReminderService** (`backend/src/bounty/bounty-reminder.service.ts`)
   - Runs every 6 hours via `@Cron('0 */6 * * *')`
   - Finds OPEN bounties expiring within 20-26 hours
   - Sends reminder emails to guild owners or bounty creators
   - Marks bounties as `reminderSent: true` to prevent duplicate emails

3. **MailerService** (`backend/src/mailer/mailer.service.ts`)
   - Added `sendBountyReminderEmail()` method
   - Formatted deadline display with timezone
   - Falls back to console logging when SMTP is not configured

4. **BountyModule** (`backend/src/bounty/bounty.module.ts`)
   - Imported `ScheduleModule.forRoot()` for cron jobs
   - Registered `BountyReminderService` as provider

### Testing

- Code follows existing project patterns
- Email sending has SMTP fallback for development
- Duplicate prevention via `reminderSent` flag

## Test Plan

- [ ] Run Prisma migration: `npx prisma migrate dev`
- [ ] Verify cron job starts with application
- [ ] Configure SMTP env vars to test email delivery
- [ ] Create test bounty with deadline 24 hours from now
- [ ] Verify reminder email is sent and `reminderSent` flag is set

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)