### PR TITLE
feat: implement guild discovery TVL sorting (closes #387)

### DIFF
--- a/backend/src/guild/dto/search-guild.dto.ts
+++ b/backend/src/guild/dto/search-guild.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsInt, Min } from 'class-validator';
+import { IsOptional, IsString, IsInt, Min, IsIn } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class SearchGuildDto {
@@ -17,4 +17,9 @@ export class SearchGuildDto {
   @IsInt()
   @Min(1)
   size?: number = 20;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['tvl', 'members', 'bounties', ''])
+  sort?: string;
 }

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -58,7 +58,7 @@ export class GuildController {
 
   @Get()
   async search(@Query() query: SearchGuildDto) {
-    return this.guildService.searchGuilds(query.q, query.page, query.size);
+    return this.guildService.searchGuilds(query.q, query.page, query.size, query.sort);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/guild/guild.service.spec.ts
+++ b/backend/src/guild/guild.service.spec.ts
@@ -116,6 +116,77 @@ describe('GuildService (settings integration)', () => {
     }
   });
 
+  it('sorts guilds by TVL when sort=tvl', async () => {
+    const mockGuilds = [
+      {
+        id: 'g1',
+        name: 'Guild 1',
+        settings: { discoverable: true },
+        bounties: [{ rewardAmount: 100 }, { rewardAmount: 200 }],
+      },
+      {
+        id: 'g2',
+        name: 'Guild 2',
+        settings: { discoverable: true },
+        bounties: [{ rewardAmount: 500 }],
+      },
+      {
+        id: 'g3',
+        name: 'Guild 3',
+        settings: { discoverable: true },
+        bounties: [],
+      },
+    ];
+
+    prisma.guild.findMany.mockResolvedValue(mockGuilds);
+
+    const res = await service.searchGuilds(undefined, 0, 10, 'tvl');
+
+    // Should be sorted by TVL descending: g2 (500), g1 (300), g3 (0)
+    expect(res.items.length).toBe(3);
+    expect(res.items[0].id).toBe('g2');
+    expect(res.items[0].tvl).toBe(500);
+    expect(res.items[1].id).toBe('g1');
+    expect(res.items[1].tvl).toBe(300);
+    expect(res.items[2].id).toBe('g3');
+    expect(res.items[2].tvl).toBe(0);
+  });
+
+  it('paginates TVL sorted results correctly', async () => {
+    const mockGuilds = [
+      {
+        id: 'g1',
+        name: 'Guild 1',
+        settings: { discoverable: true },
+        bounties: [{ rewardAmount: 100 }],
+      },
+      {
+        id: 'g2',
+        name: 'Guild 2',
+        settings: { discoverable: true },
+        bounties: [{ rewardAmount: 500 }],
+      },
+      {
+        id: 'g3',
+        name: 'Guild 3',
+        settings: { discoverable: true },
+        bounties: [{ rewardAmount: 300 }],
+      },
+    ];
+
+    prisma.guild.findMany.mockResolvedValue(mockGuilds);
+
+    const res = await service.searchGuilds(undefined, 0, 2, 'tvl');
+
+    // Page 0, size 2: should return g2 (500) and g3 (300)
+    expect(res.items.length).toBe(2);
+    expect(res.items[0].id).toBe('g2');
+    expect(res.items[1].id).toBe('g3');
+    expect(res.total).toBe(3);
+    expect(res.page).toBe(0);
+    expect(res.size).toBe(2);
+  });
+
   it('getGuild includes active member and open bounty counts', async () => {
     const guildData = {
       id: 'guild-1',

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -175,7 +175,7 @@ export class GuildService {
     return this.prisma.guild.delete({ where: { id: guildId } });
   }
 
-  async searchGuilds(q: string | undefined, page = 0, size = 20) {
+  async searchGuilds(q: string | undefined, page = 0, size = 20, sort?: string) {
     const textFilter = q
       ? {
           OR: [
@@ -194,6 +194,51 @@ export class GuildService {
       ? { AND: [textFilter, discoverFilter] }
       : discoverFilter;
 
+    // If sorting by TVL, we need to calculate TVL for each guild
+    if (sort === 'tvl') {
+      // Get all discoverable guilds
+      const allGuilds = await this.prisma.guild.findMany({
+        where,
+        include: {
+          bounties: {
+            where: {
+              status: { in: ['OPEN', 'PENDING'] },
+            },
+            select: {
+              rewardAmount: true,
+            },
+          },
+        },
+      });
+
+      // Calculate TVL for each guild
+      const guildsWithTvl = allGuilds.map((guild) => {
+        const tvl = guild.bounties.reduce(
+          (sum, bounty) => sum + (bounty.rewardAmount || 0),
+          0,
+        );
+        return {
+          ...guild,
+          tvl,
+          bounties: undefined, // Remove bounties from response
+        };
+      });
+
+      // Sort by TVL descending
+      guildsWithTvl.sort((a, b) => b.tvl - a.tvl);
+
+      // Apply pagination
+      const paginatedItems = guildsWithTvl.slice(page * size, (page + 1) * size);
+
+      return {
+        items: paginatedItems,
+        total: guildsWithTvl.length,
+        page,
+        size,
+      };
+    }
+
+    // Default sorting (no TVL)
     const [items, total] = await Promise.all([
       this.prisma.guild.findMany({ where, skip: page * size, take: size }),
       this.prisma.guild.count({ where }),


### PR DESCRIPTION
## Summary

Implements TVL (Total Value Locked) sorting for guild discovery as requested in #387.

### Changes

1. **SearchGuildDto**: Added `sort` query parameter with validation for `'tvl'`, `'members'`, `'bounties'` values
2. **GuildService.searchGuilds**: 
   - When `sort=tvl`, fetches all discoverable guilds with their bounties
   - Calculates TVL as the sum of `rewardAmount` for all OPEN and PENDING bounties per guild
   - Sorts guilds by TVL descending
   - Applies pagination to the sorted results
3. **GuildController**: Updated to pass the `sort` parameter to the service
4. **Unit Tests**: Added tests for TVL sorting and pagination

### API Usage

```
GET /guilds?sort=tvl&page=0&size=20
```

### Acceptance Criteria

- [x] Update `GET /guilds` to accept a `sort=tvl` query parameter
- [x] The service aggregates the total balance of all bounties (OPEN + PENDING) for each guild
- [x] Return the results sorted by TVL descending

### Testing

Run the tests with:
```bash
npm test -- --testPathPattern=guild.service.spec
```