### PR TITLE
[Backend] Guild Banner Image Support & Logic

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -108,6 +108,7 @@ model Guild {
   description String?
   avatarUrl   String?
   bannerUrl   String?
+  bannerCid   String?
   ownerId     String
   settings    Json?
   memberCount Int       @default(1)

--- a/backend/src/guild/dto/update-banner-cid.dto.ts
+++ b/backend/src/guild/dto/update-banner-cid.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateBannerCidDto {
+  @ApiProperty({
+    description: 'CID (Content Identifier) for the banner image',
+    example: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco',
+  })
+  @IsString()
+  @IsNotEmpty()
+  bannerCid: string;
+}

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -21,6 +21,7 @@ import { GuildRoles } from './decorators/guild-roles.decorator';
 import { GuildService } from './guild.service';
 import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
+import { UpdateBannerCidDto } from './dto/update-banner-cid.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
 import { ApproveInviteDto } from './dto/approve-invite.dto';
 import { SearchGuildDto } from './dto/search-guild.dto';
@@ -296,5 +297,37 @@ export class GuildController {
       bannerUrl: result.bannerUrl,
       message: 'Guild banner updated successfully',
     };
+  }
+
+  /**
+   * Update guild banner CID
+   * Accepts a CID (Content Identifier) string in the request body.
+   * Only admins and owners can update this field.
+   */
+  @Patch(':id/banner')
+  @UseGuards(JwtAuthGuard, GuildRoleGuard)
+  @GuildRoles('ADMIN', 'OWNER')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update guild banner CID' })
+  @ApiParam({ name: 'id', description: 'Guild ID (UUID)' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Banner CID updated successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'Insufficient permissions',
+  })
+  async updateBannerCid(
+    @Param('id') id: string,
+    @Body() dto: UpdateBannerCidDto,
+    @Request() req: any,
+  ) {
+    const result = await this.guildService.updateGuildBannerCid(
+      id,
+      dto.bannerCid,
+      req.user.userId,
+    );
+    return result;
   }
 }

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -545,4 +545,31 @@ export class GuildService {
 
     return updated;
   }
+
+  /**
+   * Update guild banner CID (Content Identifier)
+   * Only admins and owners can update this field.
+   */
+  async updateGuildBannerCid(
+    guildId: string,
+    bannerCid: string,
+    userId: string,
+  ) {
+    await this.ensureManagePermission(guildId, userId);
+
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+    });
+
+    if (!guild) {
+      throw new NotFoundException('Guild not found');
+    }
+
+    const updated = await this.prisma.guild.update({
+      where: { id: guildId },
+      data: { bannerCid },
+    });
+
+    return updated;
+  }
 }


### PR DESCRIPTION
## Summary

Implements guild banner CID (Content Identifier) support as requested in #443.

## Changes

1. **Prisma Schema**: Added `bannerCid` field (optional string) to the `Guild` model
2. **DTO**: Created `UpdateBannerCidDto` with validation for the CID string
3. **Controller**: Added `PATCH /guilds/:id/banner` endpoint
4. **Service**: Added `updateGuildBannerCid` method

## Security

- Only users with `ADMIN` or `OWNER` role can update the banner CID
- Uses existing `GuildRoleGuard` and `@GuildRoles` decorator

## API

```
PATCH /guilds/:id/banner
Authorization: Bearer <token>
Content-Type: application/json

{
  "bannerCid": "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco"
}
```

Returns the updated guild object.

Closes #443