### PR TITLE
feat: Add API Response Sanitization Interceptor

### DIFF
--- a/backend/src/common/interceptors/sanitize-response.interceptor.spec.ts
+++ b/backend/src/common/interceptors/sanitize-response.interceptor.spec.ts
@@ -1,0 +1,253 @@
+import { TestingModule, Test } from '@nestjs/testing';
+import { SanitizeResponseInterceptor } from './sanitize-response.interceptor';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of } from 'rxjs';
+
+describe('SanitizeResponseInterceptor', () => {
+  let interceptor: SanitizeResponseInterceptor<any>;
+
+  beforeEach(() => {
+    interceptor = new SanitizeResponseInterceptor();
+  });
+
+  it('should be defined', () => {
+    expect(interceptor).toBeDefined();
+  });
+
+  it('should strip password field from simple object', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () =>
+        of({
+          id: 1,
+          name: 'John',
+          password: 'secret123',
+        }),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toEqual({ id: 1, name: 'John' });
+        expect(result).not.toHaveProperty('password');
+        done();
+      },
+    });
+  });
+
+  it('should strip twoFactorSecret field from simple object', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () =>
+        of({
+          id: 1,
+          email: 'john@example.com',
+          twoFactorSecret: 'JBSWY3DPEHPK3PXP',
+        }),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toEqual({ id: 1, email: 'john@example.com' });
+        expect(result).not.toHaveProperty('twoFactorSecret');
+        done();
+      },
+    });
+  });
+
+  it('should strip internalNote field from simple object', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () =>
+        of({
+          id: 1,
+          name: 'Guild Name',
+          internalNote: 'Admin only note',
+        }),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toEqual({ id: 1, name: 'Guild Name' });
+        expect(result).not.toHaveProperty('internalNote');
+        done();
+      },
+    });
+  });
+
+  it('should strip sensitive fields case-insensitively', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () =>
+        of({
+          id: 1,
+          Password: 'secret',
+          TWOfactorSECRET: 'secret2',
+          InternalNote: 'note',
+        }),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toEqual({ id: 1 });
+        expect(result).not.toHaveProperty('Password');
+        expect(result).not.toHaveProperty('TWOfactorSECRET');
+        expect(result).not.toHaveProperty('InternalNote');
+        done();
+      },
+    });
+  });
+
+  it('should strip sensitive fields from nested objects', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () =>
+        of({
+          id: 1,
+          user: {
+            name: 'John',
+            password: 'secret123',
+            profile: {
+              bio: 'Developer',
+              twoFactorSecret: 'secret2',
+            },
+          },
+        }),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toEqual({
+          id: 1,
+          user: {
+            name: 'John',
+            profile: {
+              bio: 'Developer',
+            },
+          },
+        });
+        expect(result.user).not.toHaveProperty('password');
+        expect(result.user.profile).not.toHaveProperty('twoFactorSecret');
+        done();
+      },
+    });
+  });
+
+  it('should strip sensitive fields from arrays of objects', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () =>
+        of([
+          { id: 1, name: 'User 1', password: 'pass1' },
+          { id: 2, name: 'User 2', password: 'pass2' },
+        ]),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toEqual([
+          { id: 1, name: 'User 1' },
+          { id: 2, name: 'User 2' },
+        ]);
+        expect(result[0]).not.toHaveProperty('password');
+        expect(result[1]).not.toHaveProperty('password');
+        done();
+      },
+    });
+  });
+
+  it('should handle null and undefined values', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () => of(null),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toBeNull();
+        done();
+      },
+    });
+  });
+
+  it('should handle primitive values', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () => of('simple string'),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toBe('simple string');
+        done();
+      },
+    });
+  });
+
+  it('should preserve non-sensitive nested data', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () =>
+        of({
+          id: 1,
+          name: 'Guild',
+          members: [
+            { userId: 1, role: 'admin', password: 'secret' },
+            { userId: 2, role: 'member', password: 'secret2' },
+          ],
+          settings: {
+            theme: 'dark',
+            internalNote: 'admin config',
+          },
+        }),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toEqual({
+          id: 1,
+          name: 'Guild',
+          members: [
+            { userId: 1, role: 'admin' },
+            { userId: 2, role: 'member' },
+          ],
+          settings: {
+            theme: 'dark',
+          },
+        });
+        done();
+      },
+    });
+  });
+
+  it('should preserve non-sensitive fields that partially match sensitive keys', (done) => {
+    const mockContext = {} as ExecutionContext;
+    const mockCallHandler: CallHandler = {
+      handle: () =>
+        of({
+          id: 1,
+          password_hash: 'abc123', // Not stripped - not exactly 'password'
+          passwordHint: 'hint', // Not stripped - not exactly 'password'
+          passwordUpdatedAt: 'date', // Not stripped - not exactly 'password'
+          twoFactorEnabled: true, // Not stripped - not exactly 'twoFactorSecret'
+          internalNotes: [], // Not stripped - not exactly 'internalNote'
+          password: 'actualPassword', // Stripped - exact match
+          twoFactorSecret: 'secret', // Stripped - exact match
+          internalNote: 'note', // Stripped - exact match
+        }),
+    };
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).not.toHaveProperty('password');
+        expect(result).not.toHaveProperty('twoFactorSecret');
+        expect(result).not.toHaveProperty('internalNote');
+        expect(result).toHaveProperty('password_hash');
+        expect(result).toHaveProperty('passwordHint');
+        expect(result).toHaveProperty('passwordUpdatedAt');
+        expect(result).toHaveProperty('twoFactorEnabled');
+        expect(result).toHaveProperty('internalNotes');
+        done();
+      },
+    });
+  });
+});

--- a/backend/src/common/interceptors/sanitize-response.interceptor.ts
+++ b/backend/src/common/interceptors/sanitize-response.interceptor.ts
@@ -1,0 +1,79 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+/**
+ * List of sensitive field keys that should be stripped from API responses.
+ * Matching is case-insensitive to catch variations like 'Password', 'PASSWORD'.
+ * Only exact matches are stripped (e.g., 'password' is stripped, but 'password_hash' is not).
+ */
+const SENSITIVE_KEYS = ['password', 'twofactorsecret', 'internalnote'];
+
+/**
+ * Deeply sanitizes an object by removing sensitive keys.
+ * Handles nested objects, arrays, and preserves non-object values.
+ *
+ * @param data - The data to sanitize (object, array, or primitive)
+ * @returns A sanitized copy of the data with sensitive fields removed
+ */
+function deepSanitize<T>(data: T): T {
+  // Handle null/undefined
+  if (data === null || data === undefined) {
+    return data;
+  }
+
+  // Handle primitive types (string, number, boolean, etc.)
+  if (typeof data !== 'object') {
+    return data;
+  }
+
+  // Handle arrays - sanitize each element
+  if (Array.isArray(data)) {
+    return data.map((item) => deepSanitize(item)) as T;
+  }
+
+  // Handle objects - filter out sensitive keys and sanitize nested values
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+    // Normalize key for case-insensitive comparison (remove camelCase casing)
+    // This ensures 'Password', 'PASSWORD', 'password' all match
+    const normalizedKey = key.toLowerCase();
+
+    // Skip sensitive keys (case-insensitive comparison)
+    if (SENSITIVE_KEYS.includes(normalizedKey)) {
+      continue;
+    }
+
+    // Recursively sanitize nested values
+    sanitized[key] = deepSanitize(value);
+  }
+
+  return sanitized as T;
+}
+
+/**
+ * NestJS Interceptor that removes sensitive fields from all API responses.
+ *
+ * This interceptor ensures that sensitive data like passwords, two-factor secrets,
+ * and internal notes are never included in API responses, even if they were
+ * inadvertently selected in database queries.
+ *
+ * Applied globally in main.ts to protect all endpoints.
+ */
+@Injectable()
+export class SanitizeResponseInterceptor<T> implements NestInterceptor<T, T> {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<T> {
+    return next.handle().pipe(
+      map((data) => {
+        // Sanitize the response data
+        return deepSanitize(data);
+      }),
+    );
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
+import { SanitizeResponseInterceptor } from './common/interceptors/sanitize-response.interceptor';
 import { WinstonLogger } from './logger/winston.logger';
 import * as express from 'express';
 import * as path from 'path';
@@ -18,6 +19,7 @@ async function bootstrap() {
   app.useGlobalFilters(new AllExceptionsFilter(httpAdapterHost));
 
   // Apply response standardization globally
+  app.useGlobalInterceptors(new SanitizeResponseInterceptor());
   app.useGlobalInterceptors(new ResponseInterceptor());
   app.use(
     '/uploads',

--- a/backend/test/test-utils.ts
+++ b/backend/test/test-utils.ts
@@ -5,6 +5,7 @@ import { PrismaService } from '../src/prisma/prisma.service';
 import { AllExceptionsFilter } from '../src/common/filters/all-exceptions.filter';
 import { HttpAdapterHost } from '@nestjs/core';
 import { ResponseInterceptor } from '../src/common/interceptors/response.interceptor';
+import { SanitizeResponseInterceptor } from '../src/common/interceptors/sanitize-response.interceptor';
 
 export interface TestApp {
   app: INestApplication;
@@ -40,6 +41,7 @@ export async function createTestApp(): Promise<TestApp> {
     }),
   );
   app.useGlobalFilters(new AllExceptionsFilter(httpAdapterHost));
+  app.useGlobalInterceptors(new SanitizeResponseInterceptor());
   app.useGlobalInterceptors(new ResponseInterceptor());
 
   await app.init();


### PR DESCRIPTION
## Summary

Closes #438

This PR adds a `SanitizeResponseInterceptor` that strips sensitive fields from all API responses before they leave the server.

## Changes

- **New interceptor**: `backend/src/common/interceptors/sanitize-response.interceptor.ts`
  - Deeply traverses outgoing JSON response data
  - Strips blacklisted sensitive keys: `password`, `twoFactorSecret`, `internalNote`
  - Case-insensitive matching (e.g., `Password`, `PASSWORD`, `password` all stripped)
  - Handles nested objects, arrays, and preserves non-object values

- **Global registration**: Applied globally in `main.ts` before the existing `ResponseInterceptor`

- **Test utilities**: Updated `test-utils.ts` to match production interceptor configuration

- **Comprehensive tests**: Added unit tests covering:
  - Basic field stripping for all three sensitive keys
  - Case-insensitive matching
  - Nested object sanitization
  - Array handling
  - Null/undefined/primitive handling
  - Preservation of non-sensitive partial matches (e.g., `password_hash`, `passwordHint`)

## Testing

All 11 unit tests pass:
```
PASS src/common/interceptors/sanitize-response.interceptor.spec.ts
  SanitizeResponseInterceptor
    ✓ should be defined
    ✓ should strip password field from simple object
    ✓ should strip twoFactorSecret field from simple object
    ✓ should strip internalNote field from simple object
    ✓ should strip sensitive fields case-insensitively
    ✓ should strip sensitive fields from nested objects
    ✓ should strip sensitive fields from arrays of objects
    ✓ should handle null and undefined values
    ✓ should handle primitive values
    ✓ should preserve non-sensitive nested data
    ✓ should preserve non-sensitive fields that partially match sensitive keys
```

## Acceptance Criteria

- [x] Create a `SanitizeResponseInterceptor` as a NestJS interceptor
- [x] Define blacklisted keys: `password`, `twoFactorSecret`, `internalNote`
- [x] Deeply traverse outgoing JSON and remove matches before they leave the server
- [x] Apply globally so user profile responses no longer include password even if selected in Prisma query