### PR TITLE
feat: Add Redis-backed profile view counter

### DIFF
--- a/backend/src/redis/redis.module.ts
+++ b/backend/src/redis/redis.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { RedisService } from './redis.service';
+
+@Global()
+@Module({
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class RedisModule {}

--- a/backend/src/redis/redis.service.ts
+++ b/backend/src/redis/redis.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, OnModuleDestroy, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+@Injectable()
+export class RedisService implements OnModuleDestroy {
+  private readonly logger = new Logger(RedisService.name);
+  private readonly client: Redis;
+
+  constructor(private configService: ConfigService) {
+    const host = this.configService.get<string>('REDIS_HOST', 'localhost');
+    const port = this.configService.get<number>('REDIS_PORT', 6379);
+    const password = this.configService.get<string>('REDIS_PASSWORD');
+    const username = this.configService.get<string>('REDIS_USERNAME');
+    const db = this.configService.get<number>('REDIS_DB', 0);
+
+    this.client = new Redis({
+      host,
+      port,
+      password,
+      username,
+      db,
+      maxRetriesPerRequest: 3,
+      retryStrategy(times: number) {
+        const delay = Math.min(times * 200, 2000);
+        return delay;
+      },
+    });
+
+    this.client.on('connect', () => {
+      this.logger.log(`Redis connected to ${host}:${port}`);
+    });
+
+    this.client.on('error', (err) => {
+      this.logger.error(`Redis connection error: ${err.message}`);
+    });
+  }
+
+  getClient(): Redis {
+    return this.client;
+  }
+
+  /**
+   * Increment a key and return the new value.
+   */
+  async incr(key: string): Promise<number> {
+    return this.client.incr(key);
+  }
+
+  /**
+   * Set a key with an expiration in seconds.
+   */
+  async setex(key: string, seconds: number, value: string): Promise<string> {
+    return this.client.setex(key, seconds, value);
+  }
+
+  /**
+   * Get a key's value.
+   */
+  async get(key: string): Promise<string | null> {
+    return this.client.get(key);
+  }
+
+  /**
+   * Check if a key exists.
+   */
+  async exists(key: string): Promise<number> {
+    return this.client.exists(key);
+  }
+
+  /**
+   * Delete a key.
+   */
+  async del(key: string): Promise<number> {
+    return this.client.del(key);
+  }
+
+  async onModuleDestroy() {
+    await this.client.quit();
+  }
+}

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -116,6 +116,9 @@ export class UserProfileDto {
 
   @ApiProperty({ description: 'User role', enum: UserRole })
   role!: UserRole;
+
+  @ApiPropertyOptional({ description: 'Profile view count' })
+  profileViewCount?: number;
 }
 
 // Update user profile

--- a/backend/src/user/profile-view.service.ts
+++ b/backend/src/user/profile-view.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from '../redis/redis.service';
+
+const VIEW_COUNT_KEY_PREFIX = 'profile:views:';
+const RATE_LIMIT_KEY_PREFIX = 'profile:viewed:';
+const RATE_LIMIT_TTL_SECONDS = 300; // 5 minutes cooldown per viewer per profile
+
+@Injectable()
+export class ProfileViewService {
+  private readonly logger = new Logger(ProfileViewService.name);
+
+  constructor(private readonly redisService: RedisService) {}
+
+  /**
+   * Record a profile view with rate limiting.
+   * Returns true if the view was counted, false if rate-limited.
+   *
+   * @param profileUserId - The user whose profile is being viewed
+   * @param viewerId - The viewer's user ID, or IP-based identifier for anonymous users
+   */
+  async recordView(profileUserId: string, viewerId: string): Promise<boolean> {
+    const rateLimitKey = `${RATE_LIMIT_KEY_PREFIX}${profileUserId}:${viewerId}`;
+
+    try {
+      // Check rate limit: if key exists, the viewer already viewed recently
+      const alreadyViewed = await this.redisService.exists(rateLimitKey);
+      if (alreadyViewed) {
+        return false;
+      }
+
+      // Increment the view count
+      const viewCountKey = `${VIEW_COUNT_KEY_PREFIX}${profileUserId}`;
+      await this.redisService.incr(viewCountKey);
+
+      // Set the rate limit key with TTL to prevent double-counting
+      await this.redisService.setex(rateLimitKey, RATE_LIMIT_TTL_SECONDS, '1');
+
+      return true;
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to record profile view for ${profileUserId}: ${error?.message ?? 'unknown error'}`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Get the current view count for a user profile.
+   * Returns 0 if no views recorded yet.
+   */
+  async getViewCount(profileUserId: string): Promise<number> {
+    const viewCountKey = `${VIEW_COUNT_KEY_PREFIX}${profileUserId}`;
+
+    try {
+      const count = await this.redisService.get(viewCountKey);
+      return count ? parseInt(count, 10) : 0;
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to get profile view count for ${profileUserId}: ${error?.message ?? 'unknown error'}`,
+      );
+      return 0;
+    }
+  }
+
+  /**
+   * Get view counts for multiple user profiles in bulk.
+   */
+  async getViewCounts(profileUserIds: string[]): Promise<Map<string, number>> {
+    const result = new Map<string, number>();
+
+    try {
+      const promises = profileUserIds.map(async (userId) => {
+        const count = await this.getViewCount(userId);
+        return { userId, count };
+      });
+
+      const results = await Promise.all(promises);
+      for (const { userId, count } of results) {
+        result.set(userId, count);
+      }
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to get bulk profile view counts: ${error?.message ?? 'unknown error'}`,
+      );
+    }
+
+    return result;
+  }
+}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -26,6 +26,7 @@ import {
   ApiConsumes,
 } from '@nestjs/swagger';
 import { UserService } from './user.service';
+import { ProfileViewService } from './profile-view.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleGuard } from '../auth/guards/role.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -41,7 +42,10 @@ import { validateImageFile } from '../common/utils/file-upload.validator';
 
 @Controller('users')
 export class UserController {
-  constructor(private userService: UserService) {}
+  constructor(
+    private userService: UserService,
+    private profileViewService: ProfileViewService,
+  ) {}
 
   /**
    * Get current authenticated user profile
@@ -65,6 +69,7 @@ export class UserController {
   /**
    * Get user profile by ID (public)
    * Returns user profile excluding sensitive fields like password, email, walletAddress
+   * Increments the profile view counter (rate-limited per viewer)
    */
   @Get(':userId')
   @ApiOperation({ summary: 'Get user profile by ID (public)' })
@@ -79,7 +84,14 @@ export class UserController {
     description: 'User not found',
   })
   @HttpCode(HttpStatus.OK)
-  async getUserProfile(@Param('userId') userId: string) {
+  async getUserProfile(@Param('userId') userId: string, @Request() req: any) {
+    // Record the profile view (fire-and-forget, non-blocking)
+    // Use authenticated user ID if available, otherwise use IP address
+    const viewerId = req.user?.userId ?? req.ip ?? 'anonymous';
+    this.profileViewService.recordView(userId, viewerId).catch(() => {
+      // Silently ignore view recording errors - don't block profile retrieval
+    });
+
     return this.userService.getUserProfile(userId);
   }
 

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,14 +1,16 @@
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
+import { ProfileViewService } from './profile-view.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
 import { StorageModule } from '../storage/storage.module';
+import { RedisModule } from '../redis/redis.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, StorageModule],
+  imports: [PrismaModule, AuthModule, StorageModule, RedisModule],
   controllers: [UserController],
-  providers: [UserService],
+  providers: [UserService, ProfileViewService],
   exports: [UserService],
 })
 export class UserModule {}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { StorageService } from '../storage/storage.service';
+import { ProfileViewService } from './profile-view.service';
 import {
   CreateUserDto,
   UpdateUserDto,
@@ -24,6 +25,7 @@ export class UserService {
   constructor(
     private prisma: PrismaService,
     private storageService: StorageService,
+    private profileViewService: ProfileViewService,
   ) {}
 
   /**
@@ -54,7 +56,13 @@ export class UserService {
       throw new NotFoundException('User not found');
     }
 
-    return user;
+    // Fetch profile view count from Redis
+    const profileViewCount = await this.profileViewService.getViewCount(userId);
+
+    return {
+      ...user,
+      profileViewCount,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Implements a Redis-backed profile view counter for issue #434.

## Changes

- **New RedisModule** (): Provides a global Redis client service using ioredis, configured via environment variables (, , , , ).

- **New ProfileViewService** (): 
  - Tracks profile views using Redis INCR
  - Rate limits viewers: same viewer cannot increment count more than once per 5 minutes per profile
  - Uses key patterns:  for counts,  for rate limiting
  - Graceful error handling with logging

- **Updated UserController**: 
  -  now records profile views (fire-and-forget, non-blocking)
  - Uses authenticated user ID if available, otherwise falls back to IP address

- **Updated UserService**: 
  -  now includes  field from Redis

- **Updated UserProfileDto**: 
  - Added optional  field with Swagger documentation

## Design Decisions

1. **Non-blocking view recording**: Views are recorded asynchronously to not delay profile responses
2. **5-minute rate limit**: Prevents same viewer from inflating counts while allowing reasonable re-visits
3. **Redis as single source of truth**: View counts are stored only in Redis for performance; no database migration needed
4. **Graceful degradation**: If Redis is unavailable, profile responses still work (view count returns 0)

## Testing

The feature can be tested by:
1. Making multiple  requests
2. Verifying  increments
3. Verifying rate limiting prevents rapid re-increments from same viewer

Closes #434