### PR TITLE
feat: Add Guild Member Join Request Moderation Queue

### DIFF
--- a/backend/prisma/migrations/20260417000000_add_moderation_queue/migration.sql
+++ b/backend/prisma/migrations/20260417000000_add_moderation_queue/migration.sql
@@ -1,0 +1,11 @@
+-- AlterEnum
+ALTER TYPE "MembershipStatus" ADD VALUE 'MODERATION_PENDING';
+
+-- AlterTable
+ALTER TABLE "guild_memberships" ADD COLUMN "message" TEXT,
+ADD COLUMN "reviewedById" TEXT,
+ADD COLUMN "reviewMessage" TEXT,
+ADD COLUMN "reviewedAt" TIMESTAMP(3);
+
+-- AddForeignKey
+ALTER TABLE "guild_memberships" ADD CONSTRAINT "guild_memberships_reviewedById_fkey" FOREIGN KEY ("reviewedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -94,6 +94,7 @@ model User {
   privacySettings    PrivacySettings?
   bountyApplications BountyApplication[]
   bountyPayouts      BountyPayout[]
+  reviewedMemberships GuildMembership[]  @relation("UserReviewedMemberships")
 
   @@map("users")
 }
@@ -132,12 +133,17 @@ model GuildMembership {
   role                GuildRole        @default(MEMBER)
   userId              String
   guildId             String
+  message             String?          // Join request message from user
+  reviewedById        String?
+  reviewMessage       String?
+  reviewedAt          DateTime?
 
   // Relations
   user  User  @relation("UserJoinedGuilds", fields: [userId], references: [id], onDelete: Cascade)
   guild Guild @relation(fields: [guildId], references: [id], onDelete: Cascade)
 
-  invitedBy User? @relation("UserInvitedMemberships", fields: [invitedById], references: [id])
+  invitedBy  User? @relation("UserInvitedMemberships", fields: [invitedById], references: [id])
+  reviewedBy User? @relation("UserReviewedMemberships", fields: [reviewedById], references: [id])
 
   //  REVOKED
   @@unique([userId, guildId])
@@ -145,6 +151,7 @@ model GuildMembership {
 }
 
 enum MembershipStatus {
+  MODERATION_PENDING
   PENDING
   APPROVED
   REJECTED

--- a/backend/src/guild/dto/create-join-request.dto.ts
+++ b/backend/src/guild/dto/create-join-request.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, IsOptional, MaxLength } from 'class-validator';
+
+export class CreateJoinRequestDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  message?: string;
+}

--- a/backend/src/guild/dto/moderate-join-request.dto.ts
+++ b/backend/src/guild/dto/moderate-join-request.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsOptional, IsIn, MaxLength } from 'class-validator';
+
+export class ModerateJoinRequestDto {
+  @IsString()
+  @IsIn(['APPROVE', 'REJECT'])
+  action!: 'APPROVE' | 'REJECT';
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reviewMessage?: string;
+}

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -25,6 +25,8 @@ import { InviteMemberDto } from './dto/invite-member.dto';
 import { ApproveInviteDto } from './dto/approve-invite.dto';
 import { SearchGuildDto } from './dto/search-guild.dto';
 import { GuildDetailsDto } from './dto/guild-details.dto';
+import { CreateJoinRequestDto } from './dto/create-join-request.dto';
+import { ModerateJoinRequestDto } from './dto/moderate-join-request.dto';
 import { validateImageFile } from '../common/utils/file-upload.validator';
 import {
   ApiTags,
@@ -200,6 +202,75 @@ export class GuildController {
     @Request() req: any,
   ) {
     return this.guildService.assignRole(id, userId, body.role, req.user.userId);
+  }
+
+  /**
+   * Submit a join request to a guild (MODERATION_PENDING status)
+   */
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/join-request')
+  @ApiOperation({ summary: 'Submit a join request to a guild' })
+  @ApiParam({ name: 'id', description: 'Guild ID' })
+  @ApiResponse({ status: 201, description: 'Join request created' })
+  @ApiResponse({ status: 400, description: 'Already a member or request pending' })
+  @ApiResponse({ status: 404, description: 'Guild not found' })
+  async createJoinRequest(
+    @Param('id') id: string,
+    @Body() dto: CreateJoinRequestDto,
+    @Request() req: any,
+  ) {
+    return this.guildService.createJoinRequest(id, req.user.userId, dto.message);
+  }
+
+  /**
+   * Get moderation queue (MODERATION_PENDING requests)
+   * Only visible to high-level admins (ADMIN, OWNER)
+   */
+  @UseGuards(JwtAuthGuard)
+  @Get(':id/moderation-queue')
+  @ApiOperation({ summary: 'Get join requests pending moderation' })
+  @ApiParam({ name: 'id', description: 'Guild ID' })
+  @ApiResponse({ status: 200, description: 'Moderation queue retrieved' })
+  @ApiResponse({ status: 403, description: 'Not authorized to view moderation queue' })
+  async getModerationQueue(
+    @Param('id') id: string,
+    @Request() req: any,
+    @Query('page') page?: string,
+    @Query('size') size?: string,
+  ) {
+    return this.guildService.getModerationQueue(
+      id,
+      req.user.userId,
+      page ? parseInt(page, 10) : 0,
+      size ? parseInt(size, 10) : 20,
+    );
+  }
+
+  /**
+   * Moderate a join request (approve to PENDING or reject)
+   * Only high-level admins (ADMIN, OWNER) can moderate
+   */
+  @UseGuards(JwtAuthGuard)
+  @Patch(':id/moderation-queue/:requestId')
+  @ApiOperation({ summary: 'Moderate a join request (approve or reject)' })
+  @ApiParam({ name: 'id', description: 'Guild ID' })
+  @ApiParam({ name: 'requestId', description: 'Join request ID' })
+  @ApiResponse({ status: 200, description: 'Request moderated successfully' })
+  @ApiResponse({ status: 403, description: 'Not authorized to moderate' })
+  @ApiResponse({ status: 404, description: 'Request not found' })
+  async moderateJoinRequest(
+    @Param('id') id: string,
+    @Param('requestId') requestId: string,
+    @Body() dto: ModerateJoinRequestDto,
+    @Request() req: any,
+  ) {
+    return this.guildService.moderateJoinRequest(
+      id,
+      requestId,
+      req.user.userId,
+      dto.action,
+      dto.reviewMessage,
+    );
   }
 
   /**

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -503,7 +503,172 @@ export class GuildService {
   }
 
   /**
-   * Update guild banner
+   * Create a join request (MODERATION_PENDING status)
+   */
+  async createJoinRequest(guildId: string, userId: string, message?: string) {
+    // Check if guild exists
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+    });
+    if (!guild) throw new NotFoundException('Guild not found');
+
+    // Check if user already has a membership or request
+    const existing = await this.prisma.guildMembership.findUnique({
+      where: { userId_guildId: { userId, guildId } },
+    });
+    if (existing) {
+      if (existing.status === 'APPROVED')
+        throw new BadRequestException('Already a member');
+      if (existing.status === 'MODERATION_PENDING')
+        throw new BadRequestException('Join request already pending moderation');
+      if (existing.status === 'PENDING')
+        throw new BadRequestException('Invite already pending');
+    }
+
+    const membership = await this.prisma.guildMembership.create({
+      data: {
+        userId,
+        guildId,
+        role: 'MEMBER',
+        status: 'MODERATION_PENDING',
+        message,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            firstName: true,
+            lastName: true,
+            avatarUrl: true,
+          },
+        },
+      },
+    });
+
+    return membership;
+  }
+
+  /**
+   * Get moderation queue (MODERATION_PENDING requests)
+   * Only visible to high-level admins (ADMIN, OWNER)
+   */
+  async getModerationQueue(guildId: string, userId: string, page = 0, size = 20) {
+    // Verify guild exists
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+    });
+    if (!guild) throw new NotFoundException('Guild not found');
+
+    // Check if user is ADMIN or OWNER
+    if (guild.ownerId !== userId) {
+      const membership = await this.prisma.guildMembership.findUnique({
+        where: { userId_guildId: { userId, guildId } },
+      });
+      if (!membership || !['ADMIN', 'OWNER'].includes(membership.role)) {
+        throw new ForbiddenException('Only admins can view moderation queue');
+      }
+    }
+
+    const where = { guildId, status: 'MODERATION_PENDING' as const };
+
+    const [items, total] = await Promise.all([
+      this.prisma.guildMembership.findMany({
+        where,
+        include: {
+          user: {
+            select: {
+              id: true,
+              username: true,
+              firstName: true,
+              lastName: true,
+              avatarUrl: true,
+              profileBio: true,
+              technicalTags: true,
+            },
+          },
+        },
+        orderBy: { createdAt: 'asc' },
+        skip: page * size,
+        take: size,
+      }),
+      this.prisma.guildMembership.count({ where }),
+    ]);
+
+    return { items, total, page, size };
+  }
+
+  /**
+   * Moderate a join request (approve to PENDING or reject)
+   * Only high-level admins (ADMIN, OWNER) can moderate
+   */
+  async moderateJoinRequest(
+    guildId: string,
+    requestId: string,
+    reviewerId: string,
+    action: 'APPROVE' | 'REJECT',
+    reviewMessage?: string,
+  ) {
+    // Verify guild exists
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+    });
+    if (!guild) throw new NotFoundException('Guild not found');
+
+    // Check if reviewer is ADMIN or OWNER
+    if (guild.ownerId !== reviewerId) {
+      const membership = await this.prisma.guildMembership.findUnique({
+        where: { userId_guildId: { userId: reviewerId, guildId } },
+      });
+      if (!membership || !['ADMIN', 'OWNER'].includes(membership.role)) {
+        throw new ForbiddenException('Only admins can moderate join requests');
+      }
+    }
+
+    // Find the request
+    const request = await this.prisma.guildMembership.findUnique({
+      where: { id: requestId },
+    });
+    if (!request) throw new NotFoundException('Join request not found');
+    if (request.guildId !== guildId)
+      throw new BadRequestException('Request does not belong to this guild');
+    if (request.status !== 'MODERATION_PENDING')
+      throw new BadRequestException('Request is not in moderation pending status');
+
+    const newStatus = action === 'APPROVE' ? 'PENDING' : 'REJECTED';
+
+    const updated = await this.prisma.guildMembership.update({
+      where: { id: requestId },
+      data: {
+        status: newStatus,
+        reviewedById: reviewerId,
+        reviewMessage,
+        reviewedAt: new Date(),
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            firstName: true,
+            lastName: true,
+            avatarUrl: true,
+          },
+        },
+        reviewedBy: {
+          select: {
+            id: true,
+            username: true,
+          },
+        },
+      },
+    });
+
+    return updated;
+  }
+
+  /**
+   * Update guild logo (avatarUrl)
    */
   async updateGuildBanner(
     guildId: string,


### PR DESCRIPTION
## Summary
Implements a moderation queue system for guild join requests, allowing high-level admins to review applications before they become visible to recruiters.

## Changes
- Added `MODERATION_PENDING` status to `MembershipStatus` enum
- Extended `GuildMembership` model with moderation fields:
  - `message` - join request message from user
  - `reviewedById` - who reviewed the request
  - `reviewMessage` - review feedback
  - `reviewedAt` - when it was reviewed

## New Endpoints
- `POST /guilds/:id/join-request` - Submit a join request (creates MODERATION_PENDING status)
- `GET /guilds/:id/moderation-queue` - View pending moderation queue (ADMIN/OWNER only)
- `PATCH /guilds/:id/moderation-queue/:requestId` - Approve to PENDING or reject request

## Workflow
1. User submits join request → status = `MODERATION_PENDING`
2. High-level admin reviews in moderation queue
3. Admin approves → status = `PENDING` (visible to recruiters)
4. Admin rejects → status = `REJECTED`

## Files Changed
- `backend/prisma/schema.prisma` - Schema updates
- `backend/prisma/migrations/` - SQL migration
- `backend/src/guild/dto/` - New DTOs
- `backend/src/guild/guild.service.ts` - Service methods
- `backend/src/guild/guild.controller.ts` - Controller endpoints

Closes #428