### PR TITLE
[Backend] Guild Member CSV Upload for Bulk Invites

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
         "bullmq": "^5.71.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
+        "csv-parse": "^6.2.1",
         "ethers": "^6.16.0",
         "nodemailer": "^6.9.3",
         "passport-jwt": "^4.0.1",
@@ -5319,6 +5320,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
     "bullmq": "^5.71.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "csv-parse": "^6.2.1",
     "ethers": "^6.16.0",
     "nodemailer": "^6.9.3",
     "passport-jwt": "^4.0.1",
@@ -89,7 +90,9 @@
       "ts"
     ],
     "rootDir": "src",
-    "setupFiles": ["dotenv/config"],
+    "setupFiles": [
+      "dotenv/config"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/backend/src/guild/dto/bulk-invite.dto.ts
+++ b/backend/src/guild/dto/bulk-invite.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BulkInviteResultDto {
+  @ApiProperty({ description: 'Number of invitations successfully created' })
+  invited!: number;
+
+  @ApiProperty({ description: 'Number of addresses skipped due to errors' })
+  skipped!: number;
+
+  @ApiProperty({ description: 'Summary message', example: 'Invited 45 users, 5 invalid addresses skipped' })
+  message!: string;
+
+  @ApiProperty({
+    description: 'Details of each row outcome',
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        identifier: { type: 'string' },
+        status: { type: 'string', enum: ['invited', 'skipped'] },
+        reason: { type: 'string', nullable: true },
+      },
+    },
+  })
+  details!: { identifier: string; status: 'invited' | 'skipped'; reason?: string }[];
+}

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -13,6 +13,7 @@ import {
   UseInterceptors,
   HttpCode,
   HttpStatus,
+  BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -91,6 +92,50 @@ export class GuildController {
     @Request() req: any,
   ) {
     return this.guildService.inviteMember(id, dto, req.user.userId);
+  }
+
+  /**
+   * Bulk invite members via CSV file upload.
+   * CSV should contain a single column of email addresses or usernames.
+   */
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/members/bulk-invite')
+  @UseGuards(GuildRoleGuard)
+  @GuildRoles('ADMIN', 'OWNER')
+  @UseInterceptors(FileInterceptor('file'))
+  @HttpCode(HttpStatus.OK)
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'CSV file with one email or username per row',
+        },
+      },
+    },
+  })
+  @ApiOperation({ summary: 'Bulk invite members via CSV upload' })
+  @ApiParam({ name: 'id', description: 'Guild ID (UUID)' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Bulk invite processed successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid CSV file or empty input',
+  })
+  async bulkInvite(
+    @Param('id') id: string,
+    @UploadedFile() file: any,
+    @Request() req: any,
+  ) {
+    if (!file?.buffer) {
+      throw new BadRequestException('CSV file is required');
+    }
+    return this.guildService.bulkInviteMembers(id, file.buffer, req.user.userId);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/guild/guild.service.spec.ts
+++ b/backend/src/guild/guild.service.spec.ts
@@ -19,7 +19,7 @@ const mockPrisma = () => ({
     findUnique: jest.fn(),
     findFirst: jest.fn(),
   },
-  user: { findUnique: jest.fn() },
+  user: { findUnique: jest.fn(), findFirst: jest.fn() },
 });
 
 const mockMailer = () => ({
@@ -184,5 +184,67 @@ describe('GuildService (settings integration)', () => {
     });
     expect(result._count.memberships).toBe(8);
     expect(result._count.bounties).toBe(2);
+  });
+
+  describe('bulkInviteMembers', () => {
+    it('invites valid users from CSV', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique
+        .mockResolvedValueOnce({ role: 'OWNER' }) // ensureManagePermission
+        .mockResolvedValueOnce(null); // existing membership check
+      prisma.user.findFirst.mockResolvedValue({ id: 'u1', email: 'a@test.com' });
+      prisma.guildMembership.create.mockResolvedValue({ id: 'm1' });
+
+      const csv = Buffer.from('a@test.com\nb@test.com\n');
+      prisma.user.findFirst
+        .mockResolvedValueOnce({ id: 'u1', email: 'a@test.com' })
+        .mockResolvedValueOnce(null); // user not found
+      prisma.guildMembership.findUnique
+        .mockResolvedValueOnce({ role: 'OWNER' }) // ensureManagePermission
+        .mockResolvedValueOnce(null) // no existing membership for u1
+        .mockResolvedValueOnce({ role: 'OWNER' }); // ensureManagePermission called again? No — it's called once
+
+      const result = await service.bulkInviteMembers('g1', csv, 'admin1');
+      expect(result.invited).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.message).toContain('Invited 1 users');
+      expect(result.message).toContain('1 invalid addresses skipped');
+    });
+
+    it('skips users already in guild', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique.mockResolvedValue({ role: 'OWNER' });
+      prisma.user.findFirst.mockResolvedValue({ id: 'u1', email: 'a@test.com' });
+      // Existing membership
+      prisma.guildMembership.findUnique
+        .mockResolvedValueOnce({ role: 'OWNER' }) // ensureManagePermission
+        .mockResolvedValueOnce({ status: 'APPROVED' }); // existing membership
+
+      const csv = Buffer.from('a@test.com\n');
+      const result = await service.bulkInviteMembers('g1', csv, 'admin1');
+      expect(result.invited).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.details[0].reason).toContain('Already approved');
+    });
+
+    it('rejects empty CSV', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique.mockResolvedValue({ role: 'OWNER' });
+
+      const csv = Buffer.from('\n\n');
+      await expect(
+        service.bulkInviteMembers('g1', csv, 'admin1'),
+      ).rejects.toThrow('CSV file is empty or has no valid rows');
+    });
+
+    it('rejects invalid CSV', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique.mockResolvedValue({ role: 'OWNER' });
+
+      const csv = Buffer.from('"unclosed quote');
+      await expect(
+        service.bulkInviteMembers('g1', csv, 'admin1'),
+      ).rejects.toThrow('Invalid CSV file');
+    });
   });
 });

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -14,6 +14,7 @@ import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
 import { randomUUID } from 'crypto';
+import { parse } from 'csv-parse/sync';
 
 @Injectable()
 export class GuildService {
@@ -456,6 +457,116 @@ export class GuildService {
       where: { id: targetMembership.id },
       data: { role: role as any },
     });
+  }
+
+  /**
+   * Bulk invite members from a CSV file buffer.
+   * CSV should have a single column with email or username per row.
+   */
+  async bulkInviteMembers(
+    guildId: string,
+    fileBuffer: Buffer,
+    invitedBy: string,
+  ) {
+    await this.ensureManagePermission(guildId, invitedBy);
+
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+    });
+    if (!guild) throw new NotFoundException('Guild not found');
+
+    let records: string[];
+    try {
+      const raw = parse(fileBuffer, {
+        columns: false,
+        skip_empty_lines: true,
+        trim: true,
+      }) as string[][];
+      records = raw.map((row) => row[0]).filter((v) => v && v.length > 0);
+    } catch {
+      throw new BadRequestException('Invalid CSV file');
+    }
+
+    if (records.length === 0) {
+      throw new BadRequestException('CSV file is empty or has no valid rows');
+    }
+
+    const details: { identifier: string; status: 'invited' | 'skipped'; reason?: string }[] = [];
+    let invited = 0;
+    let skipped = 0;
+
+    const ttlDays = process.env.INVITE_TTL_DAYS
+      ? Number(process.env.INVITE_TTL_DAYS)
+      : 7;
+
+    for (const identifier of records) {
+      // Look up user by email or username
+      const user = await this.prisma.user.findFirst({
+        where: {
+          OR: [{ email: identifier }, { username: identifier }],
+        },
+      });
+
+      if (!user) {
+        details.push({ identifier, status: 'skipped', reason: 'User not found' });
+        skipped++;
+        continue;
+      }
+
+      // Check for existing membership
+      const existing = await this.prisma.guildMembership.findUnique({
+        where: { userId_guildId: { userId: user.id, guildId } },
+      });
+
+      if (existing) {
+        details.push({
+          identifier,
+          status: 'skipped',
+          reason: `Already ${existing.status.toLowerCase().replace('_', ' ')}`,
+        });
+        skipped++;
+        continue;
+      }
+
+      const token = randomUUID();
+      const expiresAt = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000);
+
+      await this.prisma.guildMembership.create({
+        data: {
+          userId: user.id,
+          guildId,
+          role: 'MEMBER',
+          status: 'PENDING',
+          invitationToken: token,
+          invitedById: invitedBy,
+          invitationExpiresAt: expiresAt,
+        },
+      });
+
+      // Try to send invite email (non-blocking)
+      try {
+        if (user.email) {
+          await this.mailer.sendInviteEmail(
+            user.email,
+            guild.name || 'a guild',
+            token,
+            undefined,
+          );
+        }
+      } catch {
+        // don't fail on email errors
+      }
+
+      details.push({ identifier, status: 'invited' });
+      invited++;
+    }
+
+    return {
+      invited,
+      skipped,
+      message: `Invited ${invited} users, ${skipped} invalid addresses skipped`,
+      details,
+    };
   }
 
   /**


### PR DESCRIPTION
Closes #437

## Summary
Implements CSV file upload endpoint for bulk inviting members to a guild.

## Changes
- **New endpoint**: `POST /guilds/:id/members/bulk-invite` (form-data file upload)
- Parses CSV using `csv-parse`, extracts email/username from each row
- Looks up users by email or username, creates `GuildMembership` with PENDING status
- Handles duplicates gracefully (skips with reason)
- Returns summary: `{ invited, skipped, message, details[] }`

## Example Response
```json
{
  "invited": 45,
  "skipped": 5,
  "message": "Invited 45 users, 5 invalid addresses skipped",
  "details": [
    { "identifier": "alice@example.com", "status": "invited" },
    { "identifier": "unknown@test.com", "status": "skipped", "reason": "User not found" }
  ]
}
```

## Testing
- Added 4 unit tests for `bulkInviteMembers` service method
- All existing tests pass