### PR TITLE
[Backend] Guild Payout History with Asset Converters

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
         "bullmq": "^5.71.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
+        "csv-parse": "^6.2.1",
         "ethers": "^6.16.0",
         "nodemailer": "^6.9.3",
         "passport-jwt": "^4.0.1",
@@ -5319,6 +5320,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
     "bullmq": "^5.71.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "csv-parse": "^6.2.1",
     "ethers": "^6.16.0",
     "nodemailer": "^6.9.3",
     "passport-jwt": "^4.0.1",
@@ -89,7 +90,9 @@
       "ts"
     ],
     "rootDir": "src",
-    "setupFiles": ["dotenv/config"],
+    "setupFiles": [
+      "dotenv/config"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -222,6 +222,10 @@ model BountyPayout {
   status      String    @default("PENDING") // PENDING, SENT, FAILED
   processedAt DateTime?
 
+  // Asset conversion fields
+  exchangeRate Decimal? @default(1.0) // Exchange rate at time of payout (token to USD)
+  usdValue     Decimal? // Calculated USD value (amount * exchangeRate)
+
   bounty Bounty @relation(fields: [bountyId], references: [id], onDelete: Cascade)
   toUser User   @relation(fields: [toUserId], references: [id])
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { HealthModule } from './health/health.module';
 import { LoggerModule } from './logger/logger.module';
 import { QueueModule } from './queue/queue.module';
+import { CommonModule } from './common/common.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { QueueModule } from './queue/queue.module';
     SocialModule,
     HealthModule,
     QueueModule,
+    CommonModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/bounty/bounty.controller.ts
+++ b/backend/src/bounty/bounty.controller.ts
@@ -157,4 +157,13 @@ export class BountyController {
   ) {
     return this.service.reviewWork(id, dto, req.user.userId);
   }
+
+  /**
+   * Get payout history for a bounty with USD conversion values
+   * GET /bounties/:id/payouts
+   */
+  @Get(':id/payouts')
+  async getPayoutHistory(@Param('id') id: string) {
+    return this.service.getPayoutHistory(id);
+  }
 }

--- a/backend/src/bounty/bounty.service.ts
+++ b/backend/src/bounty/bounty.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { MailerService } from '../mailer/mailer.service';
+import { ExchangeRateService } from '../common/services/exchange-rate.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
 import { UpdateBountyDto } from './dto/update-bounty.dto';
 import { ApplyBountyDto } from './dto/apply-bounty.dto';
@@ -18,6 +19,7 @@ export class BountyService {
   constructor(
     private prisma: PrismaService,
     private mailer: MailerService,
+    private exchangeRateService: ExchangeRateService,
   ) {}
 
   async create(dto: CreateBountyDto, creatorId: string) {
@@ -289,15 +291,21 @@ export class BountyService {
     if (milestone.status !== 'COMPLETE')
       throw new BadRequestException('Milestone not completed');
 
-    // create payout record
+    // create payout record with exchange rate conversion
+    const token = bounty.rewardToken || 'STELLAR';
+    const exchangeRate = this.exchangeRateService.getExchangeRate(token);
+    const usdValue = Number(milestone.amount) * exchangeRate;
+
     const payout = await this.prisma.bountyPayout.create({
       data: {
         bountyId,
         toUserId: bounty.assigneeId as string,
         amount: milestone.amount,
-        token: bounty.rewardToken || 'STELLAR',
+        token,
         status: 'SENT',
         processedAt: new Date(),
+        exchangeRate,
+        usdValue,
       },
     });
 
@@ -521,5 +529,108 @@ export class BountyService {
         feedback: dto.feedback,
       };
     }
+  }
+
+  /**
+   * Get payout history for a bounty with conversion details
+   * @param bountyId The bounty ID to get payouts for
+   * @returns List of payouts with USD conversion values
+   */
+  async getPayoutHistory(bountyId: string) {
+    const bounty = await this.prisma.bounty.findUnique({
+      where: { id: bountyId },
+    });
+    if (!bounty) throw new NotFoundException('Bounty not found');
+
+    const payouts = await this.prisma.bountyPayout.findMany({
+      where: { bountyId },
+      include: {
+        toUser: {
+          select: {
+            id: true,
+            username: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    // Map payouts with conversion details
+    return payouts.map((payout: any) => ({
+      id: payout.id,
+      createdAt: payout.createdAt,
+      amount: payout.amount,
+      token: payout.token,
+      status: payout.status,
+      processedAt: payout.processedAt,
+      txRef: payout.txRef,
+      // Asset conversion details
+      exchangeRate: payout.exchangeRate,
+      usdValue: payout.usdValue,
+      // User info
+      recipient: payout.toUser,
+    }));
+  }
+
+  /**
+   * Get payout history for a guild with conversion details
+   * @param guildId The guild ID to get payouts for
+   * @param page Page number (0-indexed)
+   * @param size Page size
+   * @returns Paginated list of payouts with USD conversion values
+   */
+  async getGuildPayoutHistory(guildId: string, page = 0, size = 20) {
+    const where = {
+      bounty: {
+        guildId,
+      },
+    };
+
+    const [items, total] = await Promise.all([
+      this.prisma.bountyPayout.findMany({
+        where,
+        include: {
+          toUser: {
+            select: {
+              id: true,
+              username: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+          bounty: {
+            select: {
+              id: true,
+              title: true,
+            },
+          },
+        },
+        skip: page * size,
+        take: size,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.bountyPayout.count({ where }),
+    ]);
+
+    // Map payouts with conversion details
+    const mappedItems = items.map((payout: any) => ({
+      id: payout.id,
+      createdAt: payout.createdAt,
+      amount: payout.amount,
+      token: payout.token,
+      status: payout.status,
+      processedAt: payout.processedAt,
+      txRef: payout.txRef,
+      // Asset conversion details
+      exchangeRate: payout.exchangeRate,
+      usdValue: payout.usdValue,
+      // Related info
+      recipient: payout.toUser,
+      bounty: payout.bounty,
+    }));
+
+    return { items: mappedItems, total, page, size };
   }
 }

--- a/backend/src/common/common.module.ts
+++ b/backend/src/common/common.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { ExchangeRateService } from './services/exchange-rate.service';
+
+@Global()
+@Module({
+  providers: [ExchangeRateService],
+  exports: [ExchangeRateService],
+})
+export class CommonModule {}

--- a/backend/src/common/services/exchange-rate.service.ts
+++ b/backend/src/common/services/exchange-rate.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Mock Exchange Rate Service
+ * In a real application, this would fetch historical prices from an API.
+ * For this decoupled task, we use fixed mock exchange rates.
+ */
+@Injectable()
+export class ExchangeRateService {
+  // Mock exchange rates (token -> USD)
+  private readonly mockExchangeRates: Record<string, number> = {
+    XLM: 0.12, // 1 XLM = $0.12
+    STELLAR: 0.12,
+    USDC: 1.0, // 1 USDC = $1.00
+    USDT: 1.0, // 1 USDT = $1.00
+    BTC: 45000.0, // 1 BTC = $45,000
+    ETH: 3000.0, // 1 ETH = $3,000
+  };
+
+  /**
+   * Get the mock exchange rate for a token to USD
+   * @param token The token symbol (e.g., 'XLM', 'USDC')
+   * @returns The exchange rate (1 token = X USD)
+   */
+  getExchangeRate(token: string): number {
+    return this.mockExchangeRates[token.toUpperCase()] ?? 1.0;
+  }
+
+  /**
+   * Convert an amount from one token to USD
+   * @param amount The amount in the source token
+   * @param token The token symbol
+   * @returns The equivalent amount in USD
+   */
+  convertToUSD(amount: number, token: string): number {
+    const rate = this.getExchangeRate(token);
+    return amount * rate;
+  }
+
+  /**
+   * Get all available mock exchange rates
+   * @returns A record of token symbols to their USD exchange rates
+   */
+  getAllRates(): Record<string, number> {
+    return { ...this.mockExchangeRates };
+  }
+
+  /**
+   * Add or update a mock exchange rate
+   * @param token The token symbol
+   * @param rate The USD exchange rate
+   */
+  setMockRate(token: string, rate: number): void {
+    this.mockExchangeRates[token.toUpperCase()] = rate;
+  }
+}

--- a/backend/src/guild/dto/bulk-invite.dto.ts
+++ b/backend/src/guild/dto/bulk-invite.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BulkInviteResultDto {
+  @ApiProperty({ description: 'Number of invitations successfully created' })
+  invited!: number;
+
+  @ApiProperty({ description: 'Number of addresses skipped due to errors' })
+  skipped!: number;
+
+  @ApiProperty({ description: 'Summary message', example: 'Invited 45 users, 5 invalid addresses skipped' })
+  message!: string;
+
+  @ApiProperty({
+    description: 'Details of each row outcome',
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        identifier: { type: 'string' },
+        status: { type: 'string', enum: ['invited', 'skipped'] },
+        reason: { type: 'string', nullable: true },
+      },
+    },
+  })
+  details!: { identifier: string; status: 'invited' | 'skipped'; reason?: string }[];
+}

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -13,6 +13,7 @@ import {
   UseInterceptors,
   HttpCode,
   HttpStatus,
+  BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -91,6 +92,50 @@ export class GuildController {
     @Request() req: any,
   ) {
     return this.guildService.inviteMember(id, dto, req.user.userId);
+  }
+
+  /**
+   * Bulk invite members via CSV file upload.
+   * CSV should contain a single column of email addresses or usernames.
+   */
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/members/bulk-invite')
+  @UseGuards(GuildRoleGuard)
+  @GuildRoles('ADMIN', 'OWNER')
+  @UseInterceptors(FileInterceptor('file'))
+  @HttpCode(HttpStatus.OK)
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'CSV file with one email or username per row',
+        },
+      },
+    },
+  })
+  @ApiOperation({ summary: 'Bulk invite members via CSV upload' })
+  @ApiParam({ name: 'id', description: 'Guild ID (UUID)' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Bulk invite processed successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid CSV file or empty input',
+  })
+  async bulkInvite(
+    @Param('id') id: string,
+    @UploadedFile() file: any,
+    @Request() req: any,
+  ) {
+    if (!file?.buffer) {
+      throw new BadRequestException('CSV file is required');
+    }
+    return this.guildService.bulkInviteMembers(id, file.buffer, req.user.userId);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -20,6 +20,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { GuildRoleGuard } from './guards/guild-role.guard';
 import { GuildRoles } from './decorators/guild-roles.decorator';
 import { GuildService } from './guild.service';
+import { BountyService } from '../bounty/bounty.service';
 import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
@@ -39,7 +40,10 @@ import {
 
 @Controller('guilds')
 export class GuildController {
-  constructor(private guildService: GuildService) {}
+  constructor(
+    private guildService: GuildService,
+    private bountyService: BountyService,
+  ) {}
 
   @UseGuards(JwtAuthGuard)
   @Post()
@@ -341,5 +345,24 @@ export class GuildController {
       bannerUrl: result.bannerUrl,
       message: 'Guild banner updated successfully',
     };
+  }
+
+  /**
+   * Get payout history for a guild with USD conversion values
+   * GET /guilds/:id/payouts
+   */
+  @Get(':id/payouts')
+  @ApiOperation({ summary: 'Get guild payout history with asset conversion' })
+  @ApiParam({ name: 'id', description: 'Guild ID (UUID)' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Payout history retrieved successfully',
+  })
+  async getPayoutHistory(
+    @Param('id') id: string,
+    @Query('page') page = '0',
+    @Query('size') size = '20',
+  ) {
+    return this.bountyService.getGuildPayoutHistory(id, Number(page), Number(size));
   }
 }

--- a/backend/src/guild/guild.module.ts
+++ b/backend/src/guild/guild.module.ts
@@ -6,9 +6,10 @@ import { GuildRoleGuard } from './guards/guild-role.guard';
 import { Reflector } from '@nestjs/core';
 import { MailerModule } from '../mailer/mailer.module';
 import { StorageModule } from '../storage/storage.module';
+import { BountyModule } from '../bounty/bounty.module';
 
 @Module({
-  imports: [PrismaModule, MailerModule, StorageModule],
+  imports: [PrismaModule, MailerModule, StorageModule, BountyModule],
   providers: [GuildService, GuildRoleGuard, Reflector],
   controllers: [GuildController],
   exports: [GuildService],

--- a/backend/src/guild/guild.service.spec.ts
+++ b/backend/src/guild/guild.service.spec.ts
@@ -19,7 +19,7 @@ const mockPrisma = () => ({
     findUnique: jest.fn(),
     findFirst: jest.fn(),
   },
-  user: { findUnique: jest.fn() },
+  user: { findUnique: jest.fn(), findFirst: jest.fn() },
 });
 
 const mockMailer = () => ({
@@ -184,5 +184,67 @@ describe('GuildService (settings integration)', () => {
     });
     expect(result._count.memberships).toBe(8);
     expect(result._count.bounties).toBe(2);
+  });
+
+  describe('bulkInviteMembers', () => {
+    it('invites valid users from CSV', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique
+        .mockResolvedValueOnce({ role: 'OWNER' }) // ensureManagePermission
+        .mockResolvedValueOnce(null); // existing membership check
+      prisma.user.findFirst.mockResolvedValue({ id: 'u1', email: 'a@test.com' });
+      prisma.guildMembership.create.mockResolvedValue({ id: 'm1' });
+
+      const csv = Buffer.from('a@test.com\nb@test.com\n');
+      prisma.user.findFirst
+        .mockResolvedValueOnce({ id: 'u1', email: 'a@test.com' })
+        .mockResolvedValueOnce(null); // user not found
+      prisma.guildMembership.findUnique
+        .mockResolvedValueOnce({ role: 'OWNER' }) // ensureManagePermission
+        .mockResolvedValueOnce(null) // no existing membership for u1
+        .mockResolvedValueOnce({ role: 'OWNER' }); // ensureManagePermission called again? No — it's called once
+
+      const result = await service.bulkInviteMembers('g1', csv, 'admin1');
+      expect(result.invited).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.message).toContain('Invited 1 users');
+      expect(result.message).toContain('1 invalid addresses skipped');
+    });
+
+    it('skips users already in guild', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique.mockResolvedValue({ role: 'OWNER' });
+      prisma.user.findFirst.mockResolvedValue({ id: 'u1', email: 'a@test.com' });
+      // Existing membership
+      prisma.guildMembership.findUnique
+        .mockResolvedValueOnce({ role: 'OWNER' }) // ensureManagePermission
+        .mockResolvedValueOnce({ status: 'APPROVED' }); // existing membership
+
+      const csv = Buffer.from('a@test.com\n');
+      const result = await service.bulkInviteMembers('g1', csv, 'admin1');
+      expect(result.invited).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.details[0].reason).toContain('Already approved');
+    });
+
+    it('rejects empty CSV', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique.mockResolvedValue({ role: 'OWNER' });
+
+      const csv = Buffer.from('\n\n');
+      await expect(
+        service.bulkInviteMembers('g1', csv, 'admin1'),
+      ).rejects.toThrow('CSV file is empty or has no valid rows');
+    });
+
+    it('rejects invalid CSV', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique.mockResolvedValue({ role: 'OWNER' });
+
+      const csv = Buffer.from('"unclosed quote');
+      await expect(
+        service.bulkInviteMembers('g1', csv, 'admin1'),
+      ).rejects.toThrow('Invalid CSV file');
+    });
   });
 });

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -14,6 +14,7 @@ import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
 import { randomUUID } from 'crypto';
+import { parse } from 'csv-parse/sync';
 
 @Injectable()
 export class GuildService {
@@ -456,6 +457,116 @@ export class GuildService {
       where: { id: targetMembership.id },
       data: { role: role as any },
     });
+  }
+
+  /**
+   * Bulk invite members from a CSV file buffer.
+   * CSV should have a single column with email or username per row.
+   */
+  async bulkInviteMembers(
+    guildId: string,
+    fileBuffer: Buffer,
+    invitedBy: string,
+  ) {
+    await this.ensureManagePermission(guildId, invitedBy);
+
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+    });
+    if (!guild) throw new NotFoundException('Guild not found');
+
+    let records: string[];
+    try {
+      const raw = parse(fileBuffer, {
+        columns: false,
+        skip_empty_lines: true,
+        trim: true,
+      }) as string[][];
+      records = raw.map((row) => row[0]).filter((v) => v && v.length > 0);
+    } catch {
+      throw new BadRequestException('Invalid CSV file');
+    }
+
+    if (records.length === 0) {
+      throw new BadRequestException('CSV file is empty or has no valid rows');
+    }
+
+    const details: { identifier: string; status: 'invited' | 'skipped'; reason?: string }[] = [];
+    let invited = 0;
+    let skipped = 0;
+
+    const ttlDays = process.env.INVITE_TTL_DAYS
+      ? Number(process.env.INVITE_TTL_DAYS)
+      : 7;
+
+    for (const identifier of records) {
+      // Look up user by email or username
+      const user = await this.prisma.user.findFirst({
+        where: {
+          OR: [{ email: identifier }, { username: identifier }],
+        },
+      });
+
+      if (!user) {
+        details.push({ identifier, status: 'skipped', reason: 'User not found' });
+        skipped++;
+        continue;
+      }
+
+      // Check for existing membership
+      const existing = await this.prisma.guildMembership.findUnique({
+        where: { userId_guildId: { userId: user.id, guildId } },
+      });
+
+      if (existing) {
+        details.push({
+          identifier,
+          status: 'skipped',
+          reason: `Already ${existing.status.toLowerCase().replace('_', ' ')}`,
+        });
+        skipped++;
+        continue;
+      }
+
+      const token = randomUUID();
+      const expiresAt = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000);
+
+      await this.prisma.guildMembership.create({
+        data: {
+          userId: user.id,
+          guildId,
+          role: 'MEMBER',
+          status: 'PENDING',
+          invitationToken: token,
+          invitedById: invitedBy,
+          invitationExpiresAt: expiresAt,
+        },
+      });
+
+      // Try to send invite email (non-blocking)
+      try {
+        if (user.email) {
+          await this.mailer.sendInviteEmail(
+            user.email,
+            guild.name || 'a guild',
+            token,
+            undefined,
+          );
+        }
+      } catch {
+        // don't fail on email errors
+      }
+
+      details.push({ identifier, status: 'invited' });
+      invited++;
+    }
+
+    return {
+      invited,
+      skipped,
+      message: `Invited ${invited} users, ${skipped} invalid addresses skipped`,
+      details,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
Implements payout history tracking with currency conversion for guild bounties.

## Changes
- **ExchangeRateService**: New service for mock token-to-USD conversion with configurable exchange rates (XLM, USDC, etc.)
- **Prisma Schema**: Added  and  fields to  model to store historical conversion data
- **Payout History Endpoints**:
  -  - Get payout history for a specific bounty with USD conversion values
  -  - Get paginated payout history for all guild bounties with conversion details
- **Payout Creation**: Automatically calculates and stores USD value at the time of payout using mock exchange rates

## API Response Format
Payout records now include:
```json
{
  "id": "...",
  "amount": "100",
  "token": "XLM",
  "exchangeRate": "0.12",
  "usdValue": "12",
  "status": "SENT",
  "processedAt": "2024-01-01T00:00:00.000Z",
  "recipient": {
    "id": "...",
    "username": "..."
  }
}
```

## Notes
- Uses mock exchange rates for decoupled implementation (as per issue spec)
- Exchange rates: XLM=/usr/bin/bash.12, USDC=.00, BTC=5000, ETH=000
- USD values are calculated and stored at payout creation time

Closes #431