### PR TITLE
[Backend] User Reputation decay algorithm (#432)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
         "bullmq": "^5.71.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
+        "csv-parse": "^6.2.1",
         "ethers": "^6.16.0",
         "nodemailer": "^6.9.3",
         "passport-jwt": "^4.0.1",
@@ -5319,6 +5320,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.12",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.2.5",
         "@nestjs/terminus": "^11.1.1",
         "@nestjs/throttler": "^6.5.0",
@@ -2468,6 +2469,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.9",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
@@ -3173,6 +3187,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -5293,6 +5313,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.12",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.2.5",
     "@nestjs/terminus": "^11.1.1",
     "@nestjs/throttler": "^6.5.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
     "bullmq": "^5.71.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "csv-parse": "^6.2.1",
     "ethers": "^6.16.0",
     "nodemailer": "^6.9.3",
     "passport-jwt": "^4.0.1",
@@ -89,7 +90,9 @@
       "ts"
     ],
     "rootDir": "src",
-    "setupFiles": ["dotenv/config"],
+    "setupFiles": [
+      "dotenv/config"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -69,6 +69,7 @@ model User {
   lastLoginAt   DateTime?
   walletAddress String?   @unique
   refreshToken  String?
+  reputation    Int       @default(0)
 
   // Profile fields
   profileBio    String?
@@ -94,8 +95,49 @@ model User {
   privacySettings    PrivacySettings?
   bountyApplications BountyApplication[]
   bountyPayouts      BountyPayout[]
+  activityLogs       ActivityLog[]
+  reputationHistory  ReputationHistory[]
 
   @@map("users")
+}
+
+enum ActivityType {
+  LOGIN
+  BOUNTY_CREATED
+  BOUNTY_COMPLETED
+  GUILD_JOINED
+  FORUM_POST
+  REPUTATION_DECAY
+}
+
+model ActivityLog {
+  id        String       @id @default(cuid())
+  createdAt DateTime     @default(now())
+  userId    String
+  type      ActivityType
+  metadata  Json?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([type])
+  @@index([createdAt])
+  @@map("activity_logs")
+}
+
+model ReputationHistory {
+  id          String   @id @default(cuid())
+  createdAt   DateTime @default(now())
+  userId      String
+  amount      Int
+  reason      String
+  metadata    Json?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([createdAt])
+  @@map("reputation_history")
 }
 
 model Guild {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -222,6 +222,10 @@ model BountyPayout {
   status      String    @default("PENDING") // PENDING, SENT, FAILED
   processedAt DateTime?
 
+  // Asset conversion fields
+  exchangeRate Decimal? @default(1.0) // Exchange rate at time of payout (token to USD)
+  usdValue     Decimal? // Calculated USD value (amount * exchangeRate)
+
   bounty Bounty @relation(fields: [bountyId], references: [id], onDelete: Cascade)
   toUser User   @relation(fields: [toUserId], references: [id])
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { HealthModule } from './health/health.module';
 import { LoggerModule } from './logger/logger.module';
 import { QueueModule } from './queue/queue.module';
 import { CommonModule } from './common/common.module';
+import { ReputationModule } from './reputation/reputation.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { CommonModule } from './common/common.module';
     HealthModule,
     QueueModule,
     CommonModule,
+    ReputationModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { HealthModule } from './health/health.module';
 import { LoggerModule } from './logger/logger.module';
 import { QueueModule } from './queue/queue.module';
+import { CommonModule } from './common/common.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { QueueModule } from './queue/queue.module';
     SocialModule,
     HealthModule,
     QueueModule,
+    CommonModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/bounty/bounty.controller.ts
+++ b/backend/src/bounty/bounty.controller.ts
@@ -157,4 +157,13 @@ export class BountyController {
   ) {
     return this.service.reviewWork(id, dto, req.user.userId);
   }
+
+  /**
+   * Get payout history for a bounty with USD conversion values
+   * GET /bounties/:id/payouts
+   */
+  @Get(':id/payouts')
+  async getPayoutHistory(@Param('id') id: string) {
+    return this.service.getPayoutHistory(id);
+  }
 }

--- a/backend/src/bounty/bounty.service.ts
+++ b/backend/src/bounty/bounty.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { MailerService } from '../mailer/mailer.service';
+import { ExchangeRateService } from '../common/services/exchange-rate.service';
 import { CreateBountyDto } from './dto/create-bounty.dto';
 import { UpdateBountyDto } from './dto/update-bounty.dto';
 import { ApplyBountyDto } from './dto/apply-bounty.dto';
@@ -18,6 +19,7 @@ export class BountyService {
   constructor(
     private prisma: PrismaService,
     private mailer: MailerService,
+    private exchangeRateService: ExchangeRateService,
   ) {}
 
   async create(dto: CreateBountyDto, creatorId: string) {
@@ -289,15 +291,21 @@ export class BountyService {
     if (milestone.status !== 'COMPLETE')
       throw new BadRequestException('Milestone not completed');
 
-    // create payout record
+    // create payout record with exchange rate conversion
+    const token = bounty.rewardToken || 'STELLAR';
+    const exchangeRate = this.exchangeRateService.getExchangeRate(token);
+    const usdValue = Number(milestone.amount) * exchangeRate;
+
     const payout = await this.prisma.bountyPayout.create({
       data: {
         bountyId,
         toUserId: bounty.assigneeId as string,
         amount: milestone.amount,
-        token: bounty.rewardToken || 'STELLAR',
+        token,
         status: 'SENT',
         processedAt: new Date(),
+        exchangeRate,
+        usdValue,
       },
     });
 
@@ -521,5 +529,108 @@ export class BountyService {
         feedback: dto.feedback,
       };
     }
+  }
+
+  /**
+   * Get payout history for a bounty with conversion details
+   * @param bountyId The bounty ID to get payouts for
+   * @returns List of payouts with USD conversion values
+   */
+  async getPayoutHistory(bountyId: string) {
+    const bounty = await this.prisma.bounty.findUnique({
+      where: { id: bountyId },
+    });
+    if (!bounty) throw new NotFoundException('Bounty not found');
+
+    const payouts = await this.prisma.bountyPayout.findMany({
+      where: { bountyId },
+      include: {
+        toUser: {
+          select: {
+            id: true,
+            username: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    // Map payouts with conversion details
+    return payouts.map((payout: any) => ({
+      id: payout.id,
+      createdAt: payout.createdAt,
+      amount: payout.amount,
+      token: payout.token,
+      status: payout.status,
+      processedAt: payout.processedAt,
+      txRef: payout.txRef,
+      // Asset conversion details
+      exchangeRate: payout.exchangeRate,
+      usdValue: payout.usdValue,
+      // User info
+      recipient: payout.toUser,
+    }));
+  }
+
+  /**
+   * Get payout history for a guild with conversion details
+   * @param guildId The guild ID to get payouts for
+   * @param page Page number (0-indexed)
+   * @param size Page size
+   * @returns Paginated list of payouts with USD conversion values
+   */
+  async getGuildPayoutHistory(guildId: string, page = 0, size = 20) {
+    const where = {
+      bounty: {
+        guildId,
+      },
+    };
+
+    const [items, total] = await Promise.all([
+      this.prisma.bountyPayout.findMany({
+        where,
+        include: {
+          toUser: {
+            select: {
+              id: true,
+              username: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+          bounty: {
+            select: {
+              id: true,
+              title: true,
+            },
+          },
+        },
+        skip: page * size,
+        take: size,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.bountyPayout.count({ where }),
+    ]);
+
+    // Map payouts with conversion details
+    const mappedItems = items.map((payout: any) => ({
+      id: payout.id,
+      createdAt: payout.createdAt,
+      amount: payout.amount,
+      token: payout.token,
+      status: payout.status,
+      processedAt: payout.processedAt,
+      txRef: payout.txRef,
+      // Asset conversion details
+      exchangeRate: payout.exchangeRate,
+      usdValue: payout.usdValue,
+      // Related info
+      recipient: payout.toUser,
+      bounty: payout.bounty,
+    }));
+
+    return { items: mappedItems, total, page, size };
   }
 }

--- a/backend/src/common/common.module.ts
+++ b/backend/src/common/common.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { ExchangeRateService } from './services/exchange-rate.service';
+
+@Global()
+@Module({
+  providers: [ExchangeRateService],
+  exports: [ExchangeRateService],
+})
+export class CommonModule {}

--- a/backend/src/common/services/exchange-rate.service.ts
+++ b/backend/src/common/services/exchange-rate.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Mock Exchange Rate Service
+ * In a real application, this would fetch historical prices from an API.
+ * For this decoupled task, we use fixed mock exchange rates.
+ */
+@Injectable()
+export class ExchangeRateService {
+  // Mock exchange rates (token -> USD)
+  private readonly mockExchangeRates: Record<string, number> = {
+    XLM: 0.12, // 1 XLM = $0.12
+    STELLAR: 0.12,
+    USDC: 1.0, // 1 USDC = $1.00
+    USDT: 1.0, // 1 USDT = $1.00
+    BTC: 45000.0, // 1 BTC = $45,000
+    ETH: 3000.0, // 1 ETH = $3,000
+  };
+
+  /**
+   * Get the mock exchange rate for a token to USD
+   * @param token The token symbol (e.g., 'XLM', 'USDC')
+   * @returns The exchange rate (1 token = X USD)
+   */
+  getExchangeRate(token: string): number {
+    return this.mockExchangeRates[token.toUpperCase()] ?? 1.0;
+  }
+
+  /**
+   * Convert an amount from one token to USD
+   * @param amount The amount in the source token
+   * @param token The token symbol
+   * @returns The equivalent amount in USD
+   */
+  convertToUSD(amount: number, token: string): number {
+    const rate = this.getExchangeRate(token);
+    return amount * rate;
+  }
+
+  /**
+   * Get all available mock exchange rates
+   * @returns A record of token symbols to their USD exchange rates
+   */
+  getAllRates(): Record<string, number> {
+    return { ...this.mockExchangeRates };
+  }
+
+  /**
+   * Add or update a mock exchange rate
+   * @param token The token symbol
+   * @param rate The USD exchange rate
+   */
+  setMockRate(token: string, rate: number): void {
+    this.mockExchangeRates[token.toUpperCase()] = rate;
+  }
+}

--- a/backend/src/guild/dto/bulk-invite.dto.ts
+++ b/backend/src/guild/dto/bulk-invite.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BulkInviteResultDto {
+  @ApiProperty({ description: 'Number of invitations successfully created' })
+  invited!: number;
+
+  @ApiProperty({ description: 'Number of addresses skipped due to errors' })
+  skipped!: number;
+
+  @ApiProperty({ description: 'Summary message', example: 'Invited 45 users, 5 invalid addresses skipped' })
+  message!: string;
+
+  @ApiProperty({
+    description: 'Details of each row outcome',
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        identifier: { type: 'string' },
+        status: { type: 'string', enum: ['invited', 'skipped'] },
+        reason: { type: 'string', nullable: true },
+      },
+    },
+  })
+  details!: { identifier: string; status: 'invited' | 'skipped'; reason?: string }[];
+}

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -13,6 +13,7 @@ import {
   UseInterceptors,
   HttpCode,
   HttpStatus,
+  BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -91,6 +92,50 @@ export class GuildController {
     @Request() req: any,
   ) {
     return this.guildService.inviteMember(id, dto, req.user.userId);
+  }
+
+  /**
+   * Bulk invite members via CSV file upload.
+   * CSV should contain a single column of email addresses or usernames.
+   */
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/members/bulk-invite')
+  @UseGuards(GuildRoleGuard)
+  @GuildRoles('ADMIN', 'OWNER')
+  @UseInterceptors(FileInterceptor('file'))
+  @HttpCode(HttpStatus.OK)
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'CSV file with one email or username per row',
+        },
+      },
+    },
+  })
+  @ApiOperation({ summary: 'Bulk invite members via CSV upload' })
+  @ApiParam({ name: 'id', description: 'Guild ID (UUID)' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Bulk invite processed successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid CSV file or empty input',
+  })
+  async bulkInvite(
+    @Param('id') id: string,
+    @UploadedFile() file: any,
+    @Request() req: any,
+  ) {
+    if (!file?.buffer) {
+      throw new BadRequestException('CSV file is required');
+    }
+    return this.guildService.bulkInviteMembers(id, file.buffer, req.user.userId);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -20,6 +20,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { GuildRoleGuard } from './guards/guild-role.guard';
 import { GuildRoles } from './decorators/guild-roles.decorator';
 import { GuildService } from './guild.service';
+import { BountyService } from '../bounty/bounty.service';
 import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
@@ -39,7 +40,10 @@ import {
 
 @Controller('guilds')
 export class GuildController {
-  constructor(private guildService: GuildService) {}
+  constructor(
+    private guildService: GuildService,
+    private bountyService: BountyService,
+  ) {}
 
   @UseGuards(JwtAuthGuard)
   @Post()
@@ -341,5 +345,24 @@ export class GuildController {
       bannerUrl: result.bannerUrl,
       message: 'Guild banner updated successfully',
     };
+  }
+
+  /**
+   * Get payout history for a guild with USD conversion values
+   * GET /guilds/:id/payouts
+   */
+  @Get(':id/payouts')
+  @ApiOperation({ summary: 'Get guild payout history with asset conversion' })
+  @ApiParam({ name: 'id', description: 'Guild ID (UUID)' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Payout history retrieved successfully',
+  })
+  async getPayoutHistory(
+    @Param('id') id: string,
+    @Query('page') page = '0',
+    @Query('size') size = '20',
+  ) {
+    return this.bountyService.getGuildPayoutHistory(id, Number(page), Number(size));
   }
 }

--- a/backend/src/guild/guild.module.ts
+++ b/backend/src/guild/guild.module.ts
@@ -6,9 +6,10 @@ import { GuildRoleGuard } from './guards/guild-role.guard';
 import { Reflector } from '@nestjs/core';
 import { MailerModule } from '../mailer/mailer.module';
 import { StorageModule } from '../storage/storage.module';
+import { BountyModule } from '../bounty/bounty.module';
 
 @Module({
-  imports: [PrismaModule, MailerModule, StorageModule],
+  imports: [PrismaModule, MailerModule, StorageModule, BountyModule],
   providers: [GuildService, GuildRoleGuard, Reflector],
   controllers: [GuildController],
   exports: [GuildService],

--- a/backend/src/guild/guild.service.spec.ts
+++ b/backend/src/guild/guild.service.spec.ts
@@ -19,7 +19,7 @@ const mockPrisma = () => ({
     findUnique: jest.fn(),
     findFirst: jest.fn(),
   },
-  user: { findUnique: jest.fn() },
+  user: { findUnique: jest.fn(), findFirst: jest.fn() },
 });
 
 const mockMailer = () => ({
@@ -184,5 +184,67 @@ describe('GuildService (settings integration)', () => {
     });
     expect(result._count.memberships).toBe(8);
     expect(result._count.bounties).toBe(2);
+  });
+
+  describe('bulkInviteMembers', () => {
+    it('invites valid users from CSV', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique
+        .mockResolvedValueOnce({ role: 'OWNER' }) // ensureManagePermission
+        .mockResolvedValueOnce(null); // existing membership check
+      prisma.user.findFirst.mockResolvedValue({ id: 'u1', email: 'a@test.com' });
+      prisma.guildMembership.create.mockResolvedValue({ id: 'm1' });
+
+      const csv = Buffer.from('a@test.com\nb@test.com\n');
+      prisma.user.findFirst
+        .mockResolvedValueOnce({ id: 'u1', email: 'a@test.com' })
+        .mockResolvedValueOnce(null); // user not found
+      prisma.guildMembership.findUnique
+        .mockResolvedValueOnce({ role: 'OWNER' }) // ensureManagePermission
+        .mockResolvedValueOnce(null) // no existing membership for u1
+        .mockResolvedValueOnce({ role: 'OWNER' }); // ensureManagePermission called again? No — it's called once
+
+      const result = await service.bulkInviteMembers('g1', csv, 'admin1');
+      expect(result.invited).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.message).toContain('Invited 1 users');
+      expect(result.message).toContain('1 invalid addresses skipped');
+    });
+
+    it('skips users already in guild', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique.mockResolvedValue({ role: 'OWNER' });
+      prisma.user.findFirst.mockResolvedValue({ id: 'u1', email: 'a@test.com' });
+      // Existing membership
+      prisma.guildMembership.findUnique
+        .mockResolvedValueOnce({ role: 'OWNER' }) // ensureManagePermission
+        .mockResolvedValueOnce({ status: 'APPROVED' }); // existing membership
+
+      const csv = Buffer.from('a@test.com\n');
+      const result = await service.bulkInviteMembers('g1', csv, 'admin1');
+      expect(result.invited).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.details[0].reason).toContain('Already approved');
+    });
+
+    it('rejects empty CSV', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique.mockResolvedValue({ role: 'OWNER' });
+
+      const csv = Buffer.from('\n\n');
+      await expect(
+        service.bulkInviteMembers('g1', csv, 'admin1'),
+      ).rejects.toThrow('CSV file is empty or has no valid rows');
+    });
+
+    it('rejects invalid CSV', async () => {
+      prisma.guild.findUnique.mockResolvedValue({ id: 'g1', name: 'Test Guild' });
+      prisma.guildMembership.findUnique.mockResolvedValue({ role: 'OWNER' });
+
+      const csv = Buffer.from('"unclosed quote');
+      await expect(
+        service.bulkInviteMembers('g1', csv, 'admin1'),
+      ).rejects.toThrow('Invalid CSV file');
+    });
   });
 });

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -14,6 +14,7 @@ import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
 import { randomUUID } from 'crypto';
+import { parse } from 'csv-parse/sync';
 
 @Injectable()
 export class GuildService {
@@ -456,6 +457,116 @@ export class GuildService {
       where: { id: targetMembership.id },
       data: { role: role as any },
     });
+  }
+
+  /**
+   * Bulk invite members from a CSV file buffer.
+   * CSV should have a single column with email or username per row.
+   */
+  async bulkInviteMembers(
+    guildId: string,
+    fileBuffer: Buffer,
+    invitedBy: string,
+  ) {
+    await this.ensureManagePermission(guildId, invitedBy);
+
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+    });
+    if (!guild) throw new NotFoundException('Guild not found');
+
+    let records: string[];
+    try {
+      const raw = parse(fileBuffer, {
+        columns: false,
+        skip_empty_lines: true,
+        trim: true,
+      }) as string[][];
+      records = raw.map((row) => row[0]).filter((v) => v && v.length > 0);
+    } catch {
+      throw new BadRequestException('Invalid CSV file');
+    }
+
+    if (records.length === 0) {
+      throw new BadRequestException('CSV file is empty or has no valid rows');
+    }
+
+    const details: { identifier: string; status: 'invited' | 'skipped'; reason?: string }[] = [];
+    let invited = 0;
+    let skipped = 0;
+
+    const ttlDays = process.env.INVITE_TTL_DAYS
+      ? Number(process.env.INVITE_TTL_DAYS)
+      : 7;
+
+    for (const identifier of records) {
+      // Look up user by email or username
+      const user = await this.prisma.user.findFirst({
+        where: {
+          OR: [{ email: identifier }, { username: identifier }],
+        },
+      });
+
+      if (!user) {
+        details.push({ identifier, status: 'skipped', reason: 'User not found' });
+        skipped++;
+        continue;
+      }
+
+      // Check for existing membership
+      const existing = await this.prisma.guildMembership.findUnique({
+        where: { userId_guildId: { userId: user.id, guildId } },
+      });
+
+      if (existing) {
+        details.push({
+          identifier,
+          status: 'skipped',
+          reason: `Already ${existing.status.toLowerCase().replace('_', ' ')}`,
+        });
+        skipped++;
+        continue;
+      }
+
+      const token = randomUUID();
+      const expiresAt = new Date(Date.now() + ttlDays * 24 * 60 * 60 * 1000);
+
+      await this.prisma.guildMembership.create({
+        data: {
+          userId: user.id,
+          guildId,
+          role: 'MEMBER',
+          status: 'PENDING',
+          invitationToken: token,
+          invitedById: invitedBy,
+          invitationExpiresAt: expiresAt,
+        },
+      });
+
+      // Try to send invite email (non-blocking)
+      try {
+        if (user.email) {
+          await this.mailer.sendInviteEmail(
+            user.email,
+            guild.name || 'a guild',
+            token,
+            undefined,
+          );
+        }
+      } catch {
+        // don't fail on email errors
+      }
+
+      details.push({ identifier, status: 'invited' });
+      invited++;
+    }
+
+    return {
+      invited,
+      skipped,
+      message: `Invited ${invited} users, ${skipped} invalid addresses skipped`,
+      details,
+    };
   }
 
   /**

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -82,6 +82,14 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
     return this.prisma.notification;
   }
 
+  get activityLog() {
+    return this.prisma.activityLog;
+  }
+
+  get reputationHistory() {
+    return this.prisma.reputationHistory;
+  }
+
   // Expose Prisma utilities
   get $transaction() {
     return this.prisma.$transaction.bind(this.prisma);

--- a/backend/src/queue/queue.constants.ts
+++ b/backend/src/queue/queue.constants.ts
@@ -16,6 +16,11 @@ export const QUEUE_NAMES = {
    * Dummy queue for testing/proof of concept
    */
   DUMMY: 'dummy',
+
+  /**
+   * Queue for reputation decay processing
+   */
+  REPUTATION_DECAY: 'reputation-decay',
 } as const;
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];

--- a/backend/src/queue/queue.interfaces.ts
+++ b/backend/src/queue/queue.interfaces.ts
@@ -72,3 +72,23 @@ export interface OnChainEventJobData {
    */
   blockHeight: number;
 }
+
+/**
+ * Interface for reputation decay job data
+ */
+export interface ReputationDecayJobData {
+  /**
+   * Timestamp when the decay job was triggered
+   */
+  triggeredAt: Date;
+
+  /**
+   * Number of days of inactivity before decay applies
+   */
+  inactivityDays: number;
+
+  /**
+   * Percentage of reputation to decay (e.g., 5 for 5%)
+   */
+  decayPercentage: number;
+}

--- a/backend/src/reputation/reputation-decay.processor.ts
+++ b/backend/src/reputation/reputation-decay.processor.ts
@@ -1,0 +1,53 @@
+import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { QUEUE_NAMES } from '../queue/queue.constants';
+import { ReputationDecayJobData } from '../queue/queue.interfaces';
+import { ReputationDecayService } from './reputation-decay.service';
+
+@Processor(QUEUE_NAMES.REPUTATION_DECAY, {
+  concurrency: 1,
+})
+export class ReputationDecayProcessor extends WorkerHost {
+  private readonly logger = new Logger(ReputationDecayProcessor.name);
+
+  constructor(
+    private readonly reputationDecayService: ReputationDecayService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<ReputationDecayJobData>): Promise<{
+    processedCount: number;
+    totalDecayed: number;
+  }> {
+    this.logger.log(
+      `Processing reputation decay job ${job.id} with data: ${JSON.stringify(job.data)}`,
+    );
+
+    const result = await this.reputationDecayService.processDecay(job.data);
+
+    this.logger.log(
+      `Reputation decay job ${job.id} completed: ${result.processedCount} users processed, ${result.totalDecayed} reputation decayed`,
+    );
+
+    return result;
+  }
+
+  @OnWorkerEvent('active')
+  onActive(job: Job<ReputationDecayJobData>) {
+    this.logger.debug(`Reputation decay job ${job.id} is now active`);
+  }
+
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job<ReputationDecayJobData>) {
+    this.logger.debug(`Reputation decay job ${job.id} has completed`);
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job<ReputationDecayJobData>, error: Error) {
+    this.logger.error(
+      `Reputation decay job ${job.id} failed: ${error.message}`,
+    );
+  }
+}

--- a/backend/src/reputation/reputation-decay.scheduler.ts
+++ b/backend/src/reputation/reputation-decay.scheduler.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { QUEUE_NAMES } from '../queue/queue.constants';
+import { ReputationDecayJobData } from '../queue/queue.interfaces';
+
+/**
+ * Default configuration for reputation decay.
+ */
+const INACTIVITY_DAYS = 180;
+const DECAY_PERCENTAGE = 5;
+
+@Injectable()
+export class ReputationDecayScheduler {
+  private readonly logger = new Logger(ReputationDecayScheduler.name);
+
+  constructor(
+    @InjectQueue(QUEUE_NAMES.REPUTATION_DECAY)
+    private readonly reputationDecayQueue: Queue,
+  ) {}
+
+  /**
+   * Runs at midnight on the first day of every month.
+   * Enqueues a reputation-decay job for the BullMQ processor.
+   */
+  @Cron(CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT)
+  async scheduleDecayJob(): Promise<void> {
+    const data: ReputationDecayJobData = {
+      triggeredAt: new Date(),
+      inactivityDays: INACTIVITY_DAYS,
+      decayPercentage: DECAY_PERCENTAGE,
+    };
+
+    const job = await this.reputationDecayQueue.add(
+      'monthly-reputation-decay',
+      data,
+      {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5000 },
+        removeOnComplete: { age: 7 * 24 * 3600 },
+        removeOnFail: { age: 7 * 24 * 3600 },
+      },
+    );
+
+    this.logger.log(
+      `Enqueued reputation decay job ${job.id} (inactivity=${INACTIVITY_DAYS}d, decay=${DECAY_PERCENTAGE}%)`,
+    );
+  }
+}

--- a/backend/src/reputation/reputation-decay.service.spec.ts
+++ b/backend/src/reputation/reputation-decay.service.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReputationDecayService } from './reputation-decay.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('ReputationDecayService', () => {
+  let service: ReputationDecayService;
+  let prismaMock: {
+    user: { findMany: jest.Mock; update: jest.Mock };
+    activityLog: { findFirst: jest.Mock; create: jest.Mock };
+    reputationHistory: { create: jest.Mock };
+    $transaction: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    prismaMock = {
+      user: { findMany: jest.fn(), update: jest.fn() },
+      activityLog: { findFirst: jest.fn(), create: jest.fn() },
+      reputationHistory: { create: jest.fn() },
+      $transaction: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReputationDecayService,
+        { provide: PrismaService, useValue: prismaMock },
+      ],
+    }).compile();
+
+    service = module.get<ReputationDecayService>(ReputationDecayService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const decayJobData = {
+    triggeredAt: new Date(),
+    inactivityDays: 180,
+    decayPercentage: 5,
+  };
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should skip users with recent activity', async () => {
+    prismaMock.user.findMany.mockResolvedValue([
+      { id: 'user-1', reputation: 100 },
+    ]);
+    prismaMock.activityLog.findFirst.mockResolvedValue({
+      id: 'act-1',
+      userId: 'user-1',
+    });
+
+    const result = await service.processDecay(decayJobData);
+
+    expect(result.processedCount).toBe(0);
+    expect(result.totalDecayed).toBe(0);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('should decay reputation for inactive users', async () => {
+    prismaMock.user.findMany.mockResolvedValue([
+      { id: 'user-1', reputation: 100 },
+    ]);
+    prismaMock.activityLog.findFirst.mockResolvedValue(null);
+    prismaMock.$transaction.mockResolvedValue([]);
+
+    const result = await service.processDecay(decayJobData);
+
+    // 5% of 100 = 5
+    expect(result.processedCount).toBe(1);
+    expect(result.totalDecayed).toBe(5);
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('should floor reputation at zero', async () => {
+    prismaMock.user.findMany.mockResolvedValue([
+      { id: 'user-1', reputation: 3 },
+    ]);
+    prismaMock.activityLog.findFirst.mockResolvedValue(null);
+    prismaMock.$transaction.mockResolvedValue([]);
+
+    const result = await service.processDecay(decayJobData);
+
+    // 5% of 3 = 0.15, but minimum decay is 1
+    expect(result.processedCount).toBe(1);
+    expect(result.totalDecayed).toBe(1);
+  });
+
+  it('should not decay users with zero reputation', async () => {
+    prismaMock.user.findMany.mockResolvedValue([]);
+
+    const result = await service.processDecay(decayJobData);
+
+    expect(result.processedCount).toBe(0);
+    expect(result.totalDecayed).toBe(0);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('should handle multiple users correctly', async () => {
+    prismaMock.user.findMany.mockResolvedValue([
+      { id: 'user-1', reputation: 200 },
+      { id: 'user-2', reputation: 50 },
+      { id: 'user-3', reputation: 100 },
+    ]);
+
+    // user-1 has recent activity, user-2 and user-3 do not
+    prismaMock.activityLog.findFirst
+      .mockResolvedValueOnce({ id: 'act-1', userId: 'user-1' })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    prismaMock.$transaction.mockResolvedValue([]);
+
+    const result = await service.processDecay(decayJobData);
+
+    // user-2: 5% of 50 = 2 (floor)
+    // user-3: 5% of 100 = 5
+    expect(result.processedCount).toBe(2);
+    expect(result.totalDecayed).toBe(7);
+  });
+});

--- a/backend/src/reputation/reputation-decay.service.ts
+++ b/backend/src/reputation/reputation-decay.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { ReputationDecayJobData } from '../queue/queue.interfaces';
+
+@Injectable()
+export class ReputationDecayService {
+  private readonly logger = new Logger(ReputationDecayService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Process reputation decay for inactive users.
+   *
+   * Identifies users who have not logged any ActivityLog in the past
+   * `inactivityDays` days, then subtracts `decayPercentage`% of their
+   * current reputation (floored at 0) and records a REPUTATION_DECAY
+   * event in both ActivityLog and ReputationHistory.
+   */
+  async processDecay(data: ReputationDecayJobData): Promise<{
+    processedCount: number;
+    totalDecayed: number;
+  }> {
+    const { inactivityDays, decayPercentage } = data;
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - inactivityDays);
+
+    this.logger.log(
+      `Starting reputation decay: inactivityDays=${inactivityDays}, decayPercentage=${decayPercentage}%, cutoff=${cutoffDate.toISOString()}`,
+    );
+
+    // Find all active users whose reputation > 0
+    const users = await this.prisma.user.findMany({
+      where: {
+        isActive: true,
+        reputation: { gt: 0 },
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        reputation: true,
+      },
+    });
+
+    let processedCount = 0;
+    let totalDecayed = 0;
+
+    for (const user of users) {
+      // Check if user has any activity after the cutoff date
+      const recentActivity = await this.prisma.activityLog.findFirst({
+        where: {
+          userId: user.id,
+          createdAt: { gte: cutoffDate },
+        },
+      });
+
+      // If user has recent activity, skip
+      if (recentActivity) {
+        continue;
+      }
+
+      // Calculate decay amount (5% of current reputation, minimum 1)
+      const decayAmount = Math.max(
+        1,
+        Math.floor((user.reputation * decayPercentage) / 100),
+      );
+
+      const newReputation = Math.max(0, user.reputation - decayAmount);
+
+      // Use a transaction to ensure atomicity
+      await this.prisma.$transaction([
+        // Update user reputation
+        this.prisma.user.update({
+          where: { id: user.id },
+          data: { reputation: newReputation },
+        }),
+        // Record in reputation history
+        this.prisma.reputationHistory.create({
+          data: {
+            userId: user.id,
+            amount: -decayAmount,
+            reason: 'REPUTATION_DECAY',
+            metadata: {
+              previousReputation: user.reputation,
+              newReputation,
+              decayPercentage,
+              inactivityDays,
+              cutoffDate: cutoffDate.toISOString(),
+            },
+          },
+        }),
+        // Record activity log event
+        this.prisma.activityLog.create({
+          data: {
+            userId: user.id,
+            type: 'REPUTATION_DECAY',
+            metadata: {
+              decayAmount,
+              previousReputation: user.reputation,
+              newReputation,
+              inactivityDays,
+            },
+          },
+        }),
+      ]);
+
+      processedCount++;
+      totalDecayed += decayAmount;
+
+      this.logger.debug(
+        `Decayed ${decayAmount} reputation from user ${user.id}: ${user.reputation} -> ${newReputation}`,
+      );
+    }
+
+    this.logger.log(
+      `Reputation decay complete: ${processedCount} users processed, ${totalDecayed} total reputation decayed`,
+    );
+
+    return { processedCount, totalDecayed };
+  }
+}

--- a/backend/src/reputation/reputation.module.ts
+++ b/backend/src/reputation/reputation.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
+import { ScheduleModule } from '@nestjs/schedule';
+import { PrismaModule } from '../prisma/prisma.module';
+import { QUEUE_NAMES } from '../queue/queue.constants';
+import { ReputationDecayService } from './reputation-decay.service';
+import { ReputationDecayProcessor } from './reputation-decay.processor';
+import { ReputationDecayScheduler } from './reputation-decay.scheduler';
+
+@Module({
+  imports: [
+    ScheduleModule.forRoot(),
+    PrismaModule,
+    BullModule.registerQueue({
+      name: QUEUE_NAMES.REPUTATION_DECAY,
+    }),
+  ],
+  providers: [
+    ReputationDecayService,
+    ReputationDecayProcessor,
+    ReputationDecayScheduler,
+  ],
+  exports: [ReputationDecayService],
+})
+export class ReputationModule {}


### PR DESCRIPTION
## Summary
Implements the reputation decay background job as described in #432.

## Changes
- **Prisma Schema**: Added ActivityLog, ReputationHistory models and reputation field (Int, default 0) to User
- **ReputationDecayService**: Core decay logic
  - Finds users with no ActivityLog in the past 180 days
  - Decays 5% of their current reputation (minimum 1 point)
  - Floors reputation at zero (never negative)
  - Records REPUTATION_DECAY events in both ActivityLog and ReputationHistory
  - Uses Prisma transactions for atomicity
- **ReputationDecayProcessor**: BullMQ worker that processes decay jobs
- **ReputationDecayScheduler**: Monthly cron job (1st of each month at midnight) that enqueues decay jobs
- **Queue integration**: New REPUTATION_DECAY queue registered in QueueModule

## Testing
- Unit tests for ReputationDecayService (6 tests, all passing)
- Build compiles successfully

Closes #432