### PR TITLE
feat: add social platform identification utility (#427)

### DIFF
--- a/backend/src/common/utils/__tests__/social.util.spec.ts
+++ b/backend/src/common/utils/__tests__/social.util.spec.ts
@@ -1,0 +1,381 @@
+import { SocialUtil, PlatformEnum } from '../social.util';
+
+describe('SocialUtil', () => {
+  describe('identifyPlatform', () => {
+    describe('GitHub', () => {
+      it('should identify github.com', () => {
+        expect(SocialUtil.identifyPlatform('https://github.com/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+
+      it('should identify www.github.com', () => {
+        expect(SocialUtil.identifyPlatform('https://www.github.com/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+
+      it('should identify gist.github.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://gist.github.com/user/abc123'),
+        ).toBe(PlatformEnum.GITHUB);
+      });
+
+      it('should identify github.io subdomains', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://user.github.io'),
+        ).toBe(PlatformEnum.GITHUB);
+      });
+
+      it('should identify GitHub URL without protocol', () => {
+        expect(SocialUtil.identifyPlatform('github.com/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+    });
+
+    describe('Twitter/X', () => {
+      it('should identify twitter.com', () => {
+        expect(SocialUtil.identifyPlatform('https://twitter.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+
+      it('should identify x.com', () => {
+        expect(SocialUtil.identifyPlatform('https://x.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+
+      it('should identify www.twitter.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://www.twitter.com/user'),
+        ).toBe(PlatformEnum.TWITTER);
+      });
+
+      it('should identify www.x.com', () => {
+        expect(SocialUtil.identifyPlatform('https://www.x.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+
+      it('should identify mobile.twitter.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://mobile.twitter.com/user'),
+        ).toBe(PlatformEnum.TWITTER);
+      });
+
+      it('should identify mobile.x.com', () => {
+        expect(SocialUtil.identifyPlatform('https://mobile.x.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+
+      it('should identify Twitter URL without protocol', () => {
+        expect(SocialUtil.identifyPlatform('twitter.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+    });
+
+    describe('Discord', () => {
+      it('should identify discord.gg', () => {
+        expect(SocialUtil.identifyPlatform('https://discord.gg/invite')).toBe(
+          PlatformEnum.DISCORD,
+        );
+      });
+
+      it('should identify www.discord.gg', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://www.discord.gg/invite'),
+        ).toBe(PlatformEnum.DISCORD);
+      });
+
+      it('should identify discord.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://discord.com/users/123'),
+        ).toBe(PlatformEnum.DISCORD);
+      });
+
+      it('should identify discordapp.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://discordapp.com/invite/abc'),
+        ).toBe(PlatformEnum.DISCORD);
+      });
+
+      it('should identify Discord URL without protocol', () => {
+        expect(SocialUtil.identifyPlatform('discord.gg/invite')).toBe(
+          PlatformEnum.DISCORD,
+        );
+      });
+    });
+
+    describe('LinkedIn', () => {
+      it('should identify linkedin.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://linkedin.com/in/user'),
+        ).toBe(PlatformEnum.LINKEDIN);
+      });
+
+      it('should identify lnkd.in', () => {
+        expect(SocialUtil.identifyPlatform('https://lnkd.in/abc')).toBe(
+          PlatformEnum.LINKEDIN,
+        );
+      });
+    });
+
+    describe('YouTube', () => {
+      it('should identify youtube.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://youtube.com/@channel'),
+        ).toBe(PlatformEnum.YOUTUBE);
+      });
+
+      it('should identify youtu.be', () => {
+        expect(SocialUtil.identifyPlatform('https://youtu.be/abc123')).toBe(
+          PlatformEnum.YOUTUBE,
+        );
+      });
+
+      it('should identify m.youtube.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://m.youtube.com/watch?v=abc'),
+        ).toBe(PlatformEnum.YOUTUBE);
+      });
+    });
+
+    describe('Instagram', () => {
+      it('should identify instagram.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://instagram.com/user'),
+        ).toBe(PlatformEnum.INSTAGRAM);
+      });
+
+      it('should identify instagr.am', () => {
+        expect(SocialUtil.identifyPlatform('https://instagr.am/p/abc')).toBe(
+          PlatformEnum.INSTAGRAM,
+        );
+      });
+    });
+
+    describe('Facebook', () => {
+      it('should identify facebook.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://facebook.com/user'),
+        ).toBe(PlatformEnum.FACEBOOK);
+      });
+
+      it('should identify fb.com', () => {
+        expect(SocialUtil.identifyPlatform('https://fb.com/user')).toBe(
+          PlatformEnum.FACEBOOK,
+        );
+      });
+
+      it('should identify fb.me', () => {
+        expect(SocialUtil.identifyPlatform('https://fb.me/user')).toBe(
+          PlatformEnum.FACEBOOK,
+        );
+      });
+    });
+
+    describe('TikTok', () => {
+      it('should identify tiktok.com', () => {
+        expect(SocialUtil.identifyPlatform('https://tiktok.com/@user')).toBe(
+          PlatformEnum.TIKTOK,
+        );
+      });
+
+      it('should identify vm.tiktok.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://vm.tiktok.com/abc123'),
+        ).toBe(PlatformEnum.TIKTOK);
+      });
+    });
+
+    describe('Reddit', () => {
+      it('should identify reddit.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://reddit.com/u/user'),
+        ).toBe(PlatformEnum.REDDIT);
+      });
+
+      it('should identify redd.it', () => {
+        expect(SocialUtil.identifyPlatform('https://redd.it/abc123')).toBe(
+          PlatformEnum.REDDIT,
+        );
+      });
+
+      it('should identify old.reddit.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://old.reddit.com/r/subreddit'),
+        ).toBe(PlatformEnum.REDDIT);
+      });
+
+      it('should identify np.reddit.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://np.reddit.com/r/subreddit'),
+        ).toBe(PlatformEnum.REDDIT);
+      });
+    });
+
+    describe('Twitch', () => {
+      it('should identify twitch.tv', () => {
+        expect(SocialUtil.identifyPlatform('https://twitch.tv/channel')).toBe(
+          PlatformEnum.TWITCH,
+        );
+      });
+    });
+
+    describe('Unknown platforms', () => {
+      it('should return UNKNOWN for unrecognized domains', () => {
+        expect(SocialUtil.identifyPlatform('https://unknown.com/user')).toBe(
+          PlatformEnum.UNKNOWN,
+        );
+      });
+
+      it('should return UNKNOWN for invalid URLs', () => {
+        expect(SocialUtil.identifyPlatform('not-a-url')).toBe(
+          PlatformEnum.UNKNOWN,
+        );
+      });
+
+      it('should return UNKNOWN for empty string', () => {
+        expect(SocialUtil.identifyPlatform('')).toBe(PlatformEnum.UNKNOWN);
+      });
+
+      it('should return UNKNOWN for null/undefined', () => {
+        expect(SocialUtil.identifyPlatform(null as any)).toBe(
+          PlatformEnum.UNKNOWN,
+        );
+        expect(SocialUtil.identifyPlatform(undefined as any)).toBe(
+          PlatformEnum.UNKNOWN,
+        );
+      });
+    });
+
+    describe('Case insensitivity', () => {
+      it('should handle uppercase domains', () => {
+        expect(SocialUtil.identifyPlatform('https://GITHUB.COM/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+
+      it('should handle mixed case domains', () => {
+        expect(SocialUtil.identifyPlatform('https://GitHub.Com/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+    });
+  });
+
+  describe('extractHandle', () => {
+    it('should extract handle from GitHub URL', () => {
+      expect(SocialUtil.extractHandle('https://github.com/octocat')).toBe(
+        'octocat',
+      );
+    });
+
+    it('should extract handle from Twitter URL', () => {
+      expect(SocialUtil.extractHandle('https://twitter.com/user')).toBe(
+        'user',
+      );
+    });
+
+    it('should extract handle from Discord invite URL', () => {
+      expect(SocialUtil.extractHandle('https://discord.gg/abc123')).toBe(
+        'abc123',
+      );
+    });
+
+    it('should extract handle from LinkedIn URL', () => {
+      expect(SocialUtil.extractHandle('https://linkedin.com/in/username')).toBe(
+        'username',
+      );
+    });
+
+    it('should extract handle from Instagram URL', () => {
+      expect(SocialUtil.extractHandle('https://instagram.com/user')).toBe(
+        'user',
+      );
+    });
+
+    it('should return null for non-handle paths', () => {
+      expect(SocialUtil.extractHandle('https://twitter.com/share')).toBeNull();
+      expect(
+        SocialUtil.extractHandle('https://twitter.com/hashtag/test'),
+      ).toBeNull();
+    });
+
+    it('should return null for invalid URLs', () => {
+      expect(SocialUtil.extractHandle('not-a-url')).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      expect(SocialUtil.extractHandle('')).toBeNull();
+    });
+
+    it('should handle URLs without protocol', () => {
+      expect(SocialUtil.extractHandle('github.com/octocat')).toBe('octocat');
+    });
+  });
+
+  describe('getIconName', () => {
+    it('should return github icon name', () => {
+      expect(SocialUtil.getIconName(PlatformEnum.GITHUB)).toBe('github');
+    });
+
+    it('should return twitter icon name', () => {
+      expect(SocialUtil.getIconName(PlatformEnum.TWITTER)).toBe('twitter');
+    });
+
+    it('should return discord icon name', () => {
+      expect(SocialUtil.getIconName(PlatformEnum.DISCORD)).toBe('discord');
+    });
+
+    it('should return link icon name for unknown', () => {
+      expect(SocialUtil.getIconName(PlatformEnum.UNKNOWN)).toBe('link');
+    });
+  });
+
+  describe('enrichUrl', () => {
+    it('should enrich GitHub URL', () => {
+      const result = SocialUtil.enrichUrl('https://github.com/octocat');
+      expect(result).toEqual({
+        url: 'https://github.com/octocat',
+        platform: PlatformEnum.GITHUB,
+        iconName: 'github',
+        handle: 'octocat',
+      });
+    });
+
+    it('should enrich Twitter URL', () => {
+      const result = SocialUtil.enrichUrl('https://twitter.com/user');
+      expect(result).toEqual({
+        url: 'https://twitter.com/user',
+        platform: PlatformEnum.TWITTER,
+        iconName: 'twitter',
+        handle: 'user',
+      });
+    });
+
+    it('should enrich Discord URL', () => {
+      const result = SocialUtil.enrichUrl('https://discord.gg/abc123');
+      expect(result).toEqual({
+        url: 'https://discord.gg/abc123',
+        platform: PlatformEnum.DISCORD,
+        iconName: 'discord',
+        handle: 'abc123',
+      });
+    });
+
+    it('should enrich unknown URL', () => {
+      const result = SocialUtil.enrichUrl('https://example.com/user');
+      expect(result).toEqual({
+        url: 'https://example.com/user',
+        platform: PlatformEnum.UNKNOWN,
+        iconName: 'link',
+        handle: 'user',
+      });
+    });
+  });
+});

--- a/backend/src/common/utils/social.util.ts
+++ b/backend/src/common/utils/social.util.ts
@@ -1,0 +1,277 @@
+/**
+ * Social platform identification utility
+ * Identifies social platforms from URLs for enriching user profiles with icon metadata
+ */
+
+export enum PlatformEnum {
+  GITHUB = 'github',
+  TWITTER = 'twitter',
+  DISCORD = 'discord',
+  LINKEDIN = 'linkedin',
+  YOUTUBE = 'youtube',
+  INSTAGRAM = 'instagram',
+  FACEBOOK = 'facebook',
+  TIKTOK = 'tiktok',
+  REDDIT = 'reddit',
+  TWITCH = 'twitch',
+  UNKNOWN = 'unknown',
+}
+
+interface PlatformPattern {
+  platform: PlatformEnum;
+  domainPatterns: RegExp[];
+}
+
+const PLATFORM_PATTERNS: PlatformPattern[] = [
+  {
+    platform: PlatformEnum.GITHUB,
+    domainPatterns: [
+      /^(?:www\.)?github\.com$/i,
+      /^(?:[\w-]+\.)?github\.io$/i,
+      /^gist\.github\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.TWITTER,
+    domainPatterns: [
+      /^(?:www\.)?twitter\.com$/i,
+      /^(?:www\.)?x\.com$/i,
+      /^mobile\.twitter\.com$/i,
+      /^mobile\.x\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.DISCORD,
+    domainPatterns: [
+      /^(?:www\.)?discord\.gg$/i,
+      /^(?:www\.)?discord\.com$/i,
+      /^(?:www\.)?discordapp\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.LINKEDIN,
+    domainPatterns: [
+      /^(?:www\.)?linkedin\.com$/i,
+      /^(?:www\.)?lnkd\.in$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.YOUTUBE,
+    domainPatterns: [
+      /^(?:www\.)?youtube\.com$/i,
+      /^(?:www\.)?youtu\.be$/i,
+      /^m\.youtube\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.INSTAGRAM,
+    domainPatterns: [
+      /^(?:www\.)?instagram\.com$/i,
+      /^(?:www\.)?instagr\.am$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.FACEBOOK,
+    domainPatterns: [
+      /^(?:www\.)?facebook\.com$/i,
+      /^(?:www\.)?fb\.com$/i,
+      /^(?:www\.)?fb\.me$/i,
+      /^m\.facebook\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.TIKTOK,
+    domainPatterns: [
+      /^(?:www\.)?tiktok\.com$/i,
+      /^(?:www\.)?vm\.tiktok\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.REDDIT,
+    domainPatterns: [
+      /^(?:www\.)?reddit\.com$/i,
+      /^(?:www\.)?redd\.it$/i,
+      /^old\.reddit\.com$/i,
+      /^np\.reddit\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.TWITCH,
+    domainPatterns: [
+      /^(?:www\.)?twitch\.tv$/i,
+      /^(?:www\.)?twitch\.tech$/i,
+    ],
+  },
+];
+
+export class SocialUtil {
+  /**
+   * Identifies the social platform from a given URL
+   * @param url - The URL to identify
+   * @returns The identified platform enum value
+   *
+   * @example
+   * SocialUtil.identifyPlatform('https://github.com/user') // returns PlatformEnum.GITHUB
+   * SocialUtil.identifyPlatform('https://twitter.com/user') // returns PlatformEnum.TWITTER
+   * SocialUtil.identifyPlatform('https://x.com/user') // returns PlatformEnum.TWITTER
+   * SocialUtil.identifyPlatform('https://discord.gg/invite') // returns PlatformEnum.DISCORD
+   * SocialUtil.identifyPlatform('https://unknown.com') // returns PlatformEnum.UNKNOWN
+   */
+  static identifyPlatform(url: string): PlatformEnum {
+    if (!url || typeof url !== 'string') {
+      return PlatformEnum.UNKNOWN;
+    }
+
+    try {
+      // Add protocol if missing for URL parsing
+      let normalizedUrl = url.trim();
+      if (!normalizedUrl.match(/^https?:\/\//i)) {
+        normalizedUrl = 'https://' + normalizedUrl;
+      }
+
+      const parsedUrl = new URL(normalizedUrl);
+      const hostname = parsedUrl.hostname.toLowerCase();
+
+      for (const { platform, domainPatterns } of PLATFORM_PATTERNS) {
+        for (const pattern of domainPatterns) {
+          if (pattern.test(hostname)) {
+            return platform;
+          }
+        }
+      }
+
+      return PlatformEnum.UNKNOWN;
+    } catch {
+      // Invalid URL
+      return PlatformEnum.UNKNOWN;
+    }
+  }
+
+  /**
+   * Extracts the handle/username from a social media URL
+   * @param url - The social media URL
+   * @returns The extracted handle or null if not found
+   *
+   * @example
+   * SocialUtil.extractHandle('https://github.com/octocat') // returns 'octocat'
+   * SocialUtil.extractHandle('https://twitter.com/user') // returns 'user'
+   */
+  static extractHandle(url: string): string | null {
+    if (!url || typeof url !== 'string') {
+      return null;
+    }
+
+    try {
+      let normalizedUrl = url.trim();
+      if (!normalizedUrl.match(/^https?:\/\//i)) {
+        normalizedUrl = 'https://' + normalizedUrl;
+      }
+
+      const parsedUrl = new URL(normalizedUrl);
+      const pathname = parsedUrl.pathname;
+      const platform = this.identifyPlatform(url);
+
+      // Remove leading/trailing slashes and get path segments
+      const segments = pathname.replace(/^\/+|\/+$/g, '').split('/');
+
+      // Platform-specific handle extraction
+      switch (platform) {
+        case PlatformEnum.LINKEDIN:
+          // LinkedIn URLs: linkedin.com/in/username
+          if (segments.length >= 2 && segments[0] === 'in') {
+            return segments[1];
+          }
+          break;
+        case PlatformEnum.REDDIT:
+          // Reddit URLs: reddit.com/u/username or reddit.com/user/username
+          if (
+            segments.length >= 2 &&
+            (segments[0] === 'u' || segments[0] === 'user')
+          ) {
+            return segments[1];
+          }
+          break;
+        case PlatformEnum.YOUTUBE:
+          // YouTube URLs: youtube.com/@username or youtube.com/c/username
+          if (segments.length >= 1) {
+            if (segments[0].startsWith('@')) {
+              return segments[0].substring(1);
+            }
+            if (
+              segments.length >= 2 &&
+              (segments[0] === 'c' || segments[0] === 'channel')
+            ) {
+              return segments[1];
+            }
+          }
+          break;
+      }
+
+      // Default: get first path segment
+      if (segments.length > 0 && segments[0]) {
+        // Filter out common non-handle paths
+        const nonHandlePaths = [
+          'share',
+          'intent',
+          'hashtag',
+          'search',
+          'explore',
+          'settings',
+        ];
+        if (!nonHandlePaths.includes(segments[0].toLowerCase())) {
+          return segments[0];
+        }
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Gets the icon identifier for a platform (for frontend icon mapping)
+   * @param platform - The platform enum value
+   * @returns The icon identifier string
+   */
+  static getIconName(platform: PlatformEnum): string {
+    const iconMap: Record<PlatformEnum, string> = {
+      [PlatformEnum.GITHUB]: 'github',
+      [PlatformEnum.TWITTER]: 'twitter',
+      [PlatformEnum.DISCORD]: 'discord',
+      [PlatformEnum.LINKEDIN]: 'linkedin',
+      [PlatformEnum.YOUTUBE]: 'youtube',
+      [PlatformEnum.INSTAGRAM]: 'instagram',
+      [PlatformEnum.FACEBOOK]: 'facebook',
+      [PlatformEnum.TIKTOK]: 'tiktok',
+      [PlatformEnum.REDDIT]: 'reddit',
+      [PlatformEnum.TWITCH]: 'twitch',
+      [PlatformEnum.UNKNOWN]: 'link',
+    };
+
+    return iconMap[platform] || 'link';
+  }
+
+  /**
+   * Enriches a URL with platform metadata
+   * @param url - The social media URL
+   * @returns Object containing platform, icon name, and extracted handle
+   */
+  static enrichUrl(url: string): {
+    url: string;
+    platform: PlatformEnum;
+    iconName: string;
+    handle: string | null;
+  } {
+    const platform = this.identifyPlatform(url);
+    const iconName = this.getIconName(platform);
+    const handle = this.extractHandle(url);
+
+    return {
+      url,
+      platform,
+      iconName,
+      handle,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a social platform identification utility to address issue #427.

### Changes
- Created `SocialUtil` class with the following methods:
  - `identifyPlatform(url: string): PlatformEnum` - Identifies social platform from URL
  - `extractHandle(url: string): string | null` - Extracts username from social media URLs
  - `getIconName(platform: PlatformEnum): string` - Returns frontend icon identifiers
  - `enrichUrl(url: string)` - Returns complete platform metadata for URLs

### Supported Platforms
- **GitHub**: github.com, github.io, gist.github.com
- **Twitter/X**: twitter.com, x.com
- **Discord**: discord.gg, discord.com, discordapp.com
- **LinkedIn**: linkedin.com, lnkd.in
- **YouTube**: youtube.com, youtu.be
- **Instagram**: instagram.com, instagr.am
- **Facebook**: facebook.com, fb.com, fb.me
- **TikTok**: tiktok.com, vm.tiktok.com
- **Reddit**: reddit.com, redd.it, old.reddit.com, np.reddit.com
- **Twitch**: twitch.tv

### Testing
- Added comprehensive unit tests (57 test cases)
- All 190 tests in the test suite pass
- Tests cover various URL formats including subdomains and protocol-less URLs

### Usage Example
```typescript
import { SocialUtil, PlatformEnum } from './common/utils/social.util';

// Identify platform from URL
const platform = SocialUtil.identifyPlatform('https://github.com/user');
// Returns: PlatformEnum.GITHUB

// Enrich URL with metadata
const metadata = SocialUtil.enrichUrl('https://twitter.com/user');
// Returns: { url: '...', platform: PlatformEnum.TWITTER, iconName: 'twitter', handle: 'user' }
```

Closes #427