### PR TITLE
[Backend] Guild Treasury Low Balance Alert Service

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { HealthModule } from './health/health.module';
 import { LoggerModule } from './logger/logger.module';
 import { QueueModule } from './queue/queue.module';
+import { TreasuryModule } from './treasury/treasury.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { QueueModule } from './queue/queue.module';
     SocialModule,
     HealthModule,
     QueueModule,
+    TreasuryModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/auth/dto/auth.dto.ts
+++ b/backend/src/auth/dto/auth.dto.ts
@@ -5,25 +5,51 @@ import {
   IsOptional,
   Matches,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class RegisterDto {
+  @ApiProperty({
+    description: 'User email address for account registration',
+    example: 'user@example.com',
+  })
   @IsEmail()
   email!: string;
 
+  @ApiProperty({
+    description: 'Unique username (minimum 3 characters)',
+    example: 'stellarbuilder',
+  })
   @IsString()
   @MinLength(3)
   username!: string;
 
+  @ApiProperty({
+    description: 'User password (minimum 8 characters)',
+    example: 'StrongPassword123',
+  })
   @IsString()
   @MinLength(8)
   password!: string;
 
+  @ApiProperty({
+    description: 'User first name',
+    example: 'Gabriel',
+  })
   @IsString()
   firstName!: string;
 
+  @ApiProperty({
+    description: 'User last name',
+    example: 'Lovelace',
+  })
   @IsString()
   lastName!: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Optional Ethereum wallet address for blockchain interactions (format: 0x followed by 40 hex characters)',
+    example: '0x1111111111111111111111111111111111111111',
+  })
   @IsOptional()
   @Matches(/^0x[a-fA-F0-9]{40}$/, {
     message: 'walletAddress must be a valid Ethereum address',
@@ -32,34 +58,78 @@ export class RegisterDto {
 }
 
 export class LoginDto {
+  @ApiProperty({
+    description: 'Registered email address for authentication',
+    example: 'user@example.com',
+  })
   @IsEmail()
   email!: string;
 
+  @ApiProperty({
+    description: 'User password',
+    example: 'StrongPassword123',
+  })
   @IsString()
   password!: string;
 }
 
 export class WalletAuthDto {
+  @ApiProperty({
+    description:
+      'Ethereum wallet address used for signature-based authentication (format: 0x followed by 40 hex characters)',
+    example: '0x1111111111111111111111111111111111111111',
+  })
   @Matches(/^0x[a-fA-F0-9]{40}$/, {
     message: 'walletAddress must be a valid Ethereum address',
   })
   walletAddress!: string;
 
+  @ApiProperty({
+    description: 'Message that was signed by the wallet for verification',
+    example: 'Sign in to Stellar Guilds - Nonce: 12345',
+  })
   @IsString()
   message!: string;
 
+  @ApiProperty({
+    description: 'Cryptographic signature of the message from the wallet',
+    example: '0x...',
+  })
   @IsString()
   signature!: string;
 }
 
 export class RefreshTokenDto {
+  @ApiProperty({
+    description: 'JWT refresh token for obtaining a new access token',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
   @IsString()
   refreshToken!: string;
 }
 
 export class AuthResponseDto {
+  @ApiProperty({
+    description: 'JWT access token for API authentication',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
   accessToken!: string;
+
+  @ApiProperty({
+    description: 'JWT refresh token for obtaining new access tokens',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
   refreshToken!: string;
+
+  @ApiProperty({
+    description: 'Authenticated user information',
+    example: {
+      id: 'clx123abc456',
+      email: 'user@example.com',
+      username: 'stellarbuilder',
+      walletAddress: '0x1111111111111111111111111111111111111111',
+    },
+  })
   user!: {
     id: string;
     email: string;

--- a/backend/src/bounty/dto/apply-bounty.dto.ts
+++ b/backend/src/bounty/dto/apply-bounty.dto.ts
@@ -1,11 +1,22 @@
 import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ApplyBountyDto {
+  @ApiPropertyOptional({
+    description: 'Application message explaining why you are a good fit for this bounty',
+    example:
+      'I have extensive experience with Stellar SDK and have built similar payment integrations before...',
+    maxLength: 5000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(5000)
   message?: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional attachments or portfolio links to support your application',
+    example: ['https://github.com/username/project', 'https://portfolio.example.com'],
+  })
   @IsOptional()
   attachments?: any;
 }

--- a/backend/src/bounty/dto/create-bounty.dto.ts
+++ b/backend/src/bounty/dto/create-bounty.dto.ts
@@ -7,31 +7,63 @@ import {
   MaxLength,
   IsISO8601,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsFutureDate } from '../decorators/future-date.decorator';
 
 export class CreateBountyDto {
+  @ApiProperty({
+    description: 'Title of the bounty (max 200 characters)',
+    example: 'Build a Stellar payment integration',
+    maxLength: 200,
+  })
   @IsString()
   @MaxLength(200)
   title!: string;
 
+  @ApiProperty({
+    description: 'Detailed description of the bounty requirements and deliverables',
+    example:
+      'Create a React component that integrates with the Stellar network for processing payments...',
+    maxLength: 5000,
+  })
   @IsString()
   @MaxLength(5000)
   description!: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Reward amount in the specified token. BPS (Basis Points): 1 basis point = 0.01%. For example, 100 BPS = 1%. Use whole token amounts here.',
+    example: 500,
+    minimum: 0,
+  })
   @IsOptional()
   @IsNumber()
   @IsPositive()
   rewardAmount?: number;
 
+  @ApiPropertyOptional({
+    description:
+      'Token type or asset code for the reward (e.g., XLM, USDC, or custom token address on Stellar)',
+    example: 'XLM',
+  })
   @IsOptional()
   @IsString()
   rewardToken?: string;
 
+  @ApiPropertyOptional({
+    description: 'Deadline for bounty completion in ISO 8601 format (must be a future date)',
+    example: '2026-06-30T23:59:59.000Z',
+  })
   @IsOptional()
   @IsISO8601()
   @IsFutureDate({ message: 'Deadline must be a valid date in the future' })
   deadline?: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Guild ID to associate this bounty with. Stellar address example: GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    example: 'clx123abc456',
+  })
   @IsOptional()
   @IsString()
   guildId?: string;

--- a/backend/src/bounty/dto/create-milestone.dto.ts
+++ b/backend/src/bounty/dto/create-milestone.dto.ts
@@ -5,20 +5,39 @@ import {
   IsOptional,
   IsISO8601,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateMilestoneDto {
+  @ApiProperty({
+    description: 'Title of the milestone (max 200 characters)',
+    example: 'Complete API integration',
+    maxLength: 200,
+  })
   @IsString()
   @MaxLength(200)
   title!: string;
 
+  @ApiPropertyOptional({
+    description: 'Detailed description of what needs to be delivered for this milestone',
+    example: 'Implement and test all REST API endpoints for payment processing...',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   description?: string;
 
+  @ApiProperty({
+    description: 'Payment amount allocated to this milestone (in reward tokens)',
+    example: 250,
+  })
   @IsNumber()
   amount!: number;
 
+  @ApiPropertyOptional({
+    description: 'Due date for completing this milestone in ISO 8601 format',
+    example: '2026-05-15T23:59:59.000Z',
+  })
   @IsOptional()
   @IsISO8601()
   dueDate?: string;

--- a/backend/src/bounty/dto/find-bounty.dto.ts
+++ b/backend/src/bounty/dto/find-bounty.dto.ts
@@ -1,22 +1,41 @@
 import { IsOptional, IsString, IsNumber, Min, IsIn } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 export class FindBountyDto {
+  @ApiPropertyOptional({
+    description: 'Filter by bounty status',
+    enum: ['OPEN', 'IN_PROGRESS', 'IN_REVIEW', 'SUBMITTED_FOR_REVIEW', 'COMPLETED_PENDING_CLAIM', 'COMPLETED', 'CANCELLED'],
+    example: 'OPEN',
+  })
   @IsOptional()
   @IsString()
   @IsIn(['OPEN', 'IN_PROGRESS', 'IN_REVIEW', 'SUBMITTED_FOR_REVIEW', 'COMPLETED_PENDING_CLAIM', 'COMPLETED', 'CANCELLED'])
   status?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by reward token type (e.g., XLM, USDC)',
+    example: 'XLM',
+  })
   @IsOptional()
   @IsString()
   tokenType?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter bounties with minimum reward amount',
+    example: 100,
+    minimum: 0,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
   @Min(0)
   minReward?: number;
 
+  @ApiPropertyOptional({
+    description: 'Filter bounties by guild ID',
+    example: 'clx123abc456',
+  })
   @IsOptional()
   @IsString()
   guildId?: string;

--- a/backend/src/bounty/dto/review-work.dto.ts
+++ b/backend/src/bounty/dto/review-work.dto.ts
@@ -1,9 +1,18 @@
 import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ReviewWorkDto {
+  @ApiProperty({
+    description: 'Whether to approve (true) or reject (false) the submitted work',
+    example: true,
+  })
   @IsBoolean()
   approve!: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Feedback or comments about the submitted work',
+    example: 'Great work! The implementation is clean and well-tested.',
+  })
   @IsString()
   @IsOptional()
   feedback?: string;

--- a/backend/src/bounty/dto/submit-work.dto.ts
+++ b/backend/src/bounty/dto/submit-work.dto.ts
@@ -7,12 +7,17 @@ import {
   ValidateNested,
   IsNotEmpty,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 /**
  * DTO for submitting a single work item (PR/commit) for a bounty
  */
 export class WorkSubmissionDto {
+  @ApiProperty({
+    description: 'URL to the pull request or commit demonstrating the completed work',
+    example: 'https://github.com/username/repo/pull/42',
+  })
   @IsNotEmpty({ message: 'PR URL is required' })
   @IsUrl(
     { require_protocol: true, require_tld: true },
@@ -21,6 +26,10 @@ export class WorkSubmissionDto {
   @MaxLength(2048, { message: 'PR URL must not exceed 2048 characters' })
   prUrl!: string;
 
+  @ApiProperty({
+    description: 'Description of the work completed in this submission',
+    example: 'Implemented the Stellar payment component with test coverage...',
+  })
   @IsNotEmpty({ message: 'Description is required' })
   @IsString()
   @MaxLength(5000, { message: 'Description must not exceed 5000 characters' })
@@ -32,11 +41,19 @@ export class WorkSubmissionDto {
  * Supports multiple PR submissions with descriptions and optional attachments
  */
 export class SubmitBountyWorkDto {
+  @ApiProperty({
+    description: 'Array of work submissions (PRs/commits) for this bounty',
+    type: [WorkSubmissionDto],
+  })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => WorkSubmissionDto)
   submissions!: WorkSubmissionDto[];
 
+  @ApiPropertyOptional({
+    description: 'Optional array of attachment URLs (screenshots, documentation, etc.)',
+    example: ['https://example.com/screenshot.png', 'https://docs.example.com/readme'],
+  })
   @IsOptional()
   @IsArray()
   @IsUrl(
@@ -49,6 +66,10 @@ export class SubmitBountyWorkDto {
   })
   attachmentUrls?: string[];
 
+  @ApiPropertyOptional({
+    description: 'Additional comments or notes about the submitted work',
+    example: 'All tests pass and documentation has been updated.',
+  })
   @IsOptional()
   @IsString()
   @MaxLength(1000, { message: 'Additional comments must not exceed 1000 characters' })

--- a/backend/src/bounty/dto/update-bounty.dto.ts
+++ b/backend/src/bounty/dto/update-bounty.dto.ts
@@ -5,26 +5,49 @@ import {
   IsNumber,
   IsISO8601,
 } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateBountyDto {
+  @ApiPropertyOptional({
+    description: 'Updated title of the bounty (max 200 characters)',
+    example: 'Updated: Build a Stellar payment integration v2',
+    maxLength: 200,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(200)
   title?: string;
 
+  @ApiPropertyOptional({
+    description: 'Updated description of the bounty requirements and deliverables',
+    example: 'Updated requirements for the Stellar payment integration...',
+    maxLength: 5000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(5000)
   description?: string;
 
+  @ApiPropertyOptional({
+    description: 'Updated reward amount in the specified token',
+    example: 750,
+  })
   @IsOptional()
   @IsNumber()
   rewardAmount?: number;
 
+  @ApiPropertyOptional({
+    description: 'Updated token type for the reward (e.g., XLM, USDC)',
+    example: 'USDC',
+  })
   @IsOptional()
   @IsString()
   rewardToken?: string;
 
+  @ApiPropertyOptional({
+    description: 'Updated deadline for bounty completion in ISO 8601 format',
+    example: '2026-08-31T23:59:59.000Z',
+  })
   @IsOptional()
   @IsISO8601()
   deadline?: string;

--- a/backend/src/common/utils/__tests__/social.util.spec.ts
+++ b/backend/src/common/utils/__tests__/social.util.spec.ts
@@ -1,0 +1,381 @@
+import { SocialUtil, PlatformEnum } from '../social.util';
+
+describe('SocialUtil', () => {
+  describe('identifyPlatform', () => {
+    describe('GitHub', () => {
+      it('should identify github.com', () => {
+        expect(SocialUtil.identifyPlatform('https://github.com/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+
+      it('should identify www.github.com', () => {
+        expect(SocialUtil.identifyPlatform('https://www.github.com/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+
+      it('should identify gist.github.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://gist.github.com/user/abc123'),
+        ).toBe(PlatformEnum.GITHUB);
+      });
+
+      it('should identify github.io subdomains', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://user.github.io'),
+        ).toBe(PlatformEnum.GITHUB);
+      });
+
+      it('should identify GitHub URL without protocol', () => {
+        expect(SocialUtil.identifyPlatform('github.com/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+    });
+
+    describe('Twitter/X', () => {
+      it('should identify twitter.com', () => {
+        expect(SocialUtil.identifyPlatform('https://twitter.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+
+      it('should identify x.com', () => {
+        expect(SocialUtil.identifyPlatform('https://x.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+
+      it('should identify www.twitter.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://www.twitter.com/user'),
+        ).toBe(PlatformEnum.TWITTER);
+      });
+
+      it('should identify www.x.com', () => {
+        expect(SocialUtil.identifyPlatform('https://www.x.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+
+      it('should identify mobile.twitter.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://mobile.twitter.com/user'),
+        ).toBe(PlatformEnum.TWITTER);
+      });
+
+      it('should identify mobile.x.com', () => {
+        expect(SocialUtil.identifyPlatform('https://mobile.x.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+
+      it('should identify Twitter URL without protocol', () => {
+        expect(SocialUtil.identifyPlatform('twitter.com/user')).toBe(
+          PlatformEnum.TWITTER,
+        );
+      });
+    });
+
+    describe('Discord', () => {
+      it('should identify discord.gg', () => {
+        expect(SocialUtil.identifyPlatform('https://discord.gg/invite')).toBe(
+          PlatformEnum.DISCORD,
+        );
+      });
+
+      it('should identify www.discord.gg', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://www.discord.gg/invite'),
+        ).toBe(PlatformEnum.DISCORD);
+      });
+
+      it('should identify discord.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://discord.com/users/123'),
+        ).toBe(PlatformEnum.DISCORD);
+      });
+
+      it('should identify discordapp.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://discordapp.com/invite/abc'),
+        ).toBe(PlatformEnum.DISCORD);
+      });
+
+      it('should identify Discord URL without protocol', () => {
+        expect(SocialUtil.identifyPlatform('discord.gg/invite')).toBe(
+          PlatformEnum.DISCORD,
+        );
+      });
+    });
+
+    describe('LinkedIn', () => {
+      it('should identify linkedin.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://linkedin.com/in/user'),
+        ).toBe(PlatformEnum.LINKEDIN);
+      });
+
+      it('should identify lnkd.in', () => {
+        expect(SocialUtil.identifyPlatform('https://lnkd.in/abc')).toBe(
+          PlatformEnum.LINKEDIN,
+        );
+      });
+    });
+
+    describe('YouTube', () => {
+      it('should identify youtube.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://youtube.com/@channel'),
+        ).toBe(PlatformEnum.YOUTUBE);
+      });
+
+      it('should identify youtu.be', () => {
+        expect(SocialUtil.identifyPlatform('https://youtu.be/abc123')).toBe(
+          PlatformEnum.YOUTUBE,
+        );
+      });
+
+      it('should identify m.youtube.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://m.youtube.com/watch?v=abc'),
+        ).toBe(PlatformEnum.YOUTUBE);
+      });
+    });
+
+    describe('Instagram', () => {
+      it('should identify instagram.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://instagram.com/user'),
+        ).toBe(PlatformEnum.INSTAGRAM);
+      });
+
+      it('should identify instagr.am', () => {
+        expect(SocialUtil.identifyPlatform('https://instagr.am/p/abc')).toBe(
+          PlatformEnum.INSTAGRAM,
+        );
+      });
+    });
+
+    describe('Facebook', () => {
+      it('should identify facebook.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://facebook.com/user'),
+        ).toBe(PlatformEnum.FACEBOOK);
+      });
+
+      it('should identify fb.com', () => {
+        expect(SocialUtil.identifyPlatform('https://fb.com/user')).toBe(
+          PlatformEnum.FACEBOOK,
+        );
+      });
+
+      it('should identify fb.me', () => {
+        expect(SocialUtil.identifyPlatform('https://fb.me/user')).toBe(
+          PlatformEnum.FACEBOOK,
+        );
+      });
+    });
+
+    describe('TikTok', () => {
+      it('should identify tiktok.com', () => {
+        expect(SocialUtil.identifyPlatform('https://tiktok.com/@user')).toBe(
+          PlatformEnum.TIKTOK,
+        );
+      });
+
+      it('should identify vm.tiktok.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://vm.tiktok.com/abc123'),
+        ).toBe(PlatformEnum.TIKTOK);
+      });
+    });
+
+    describe('Reddit', () => {
+      it('should identify reddit.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://reddit.com/u/user'),
+        ).toBe(PlatformEnum.REDDIT);
+      });
+
+      it('should identify redd.it', () => {
+        expect(SocialUtil.identifyPlatform('https://redd.it/abc123')).toBe(
+          PlatformEnum.REDDIT,
+        );
+      });
+
+      it('should identify old.reddit.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://old.reddit.com/r/subreddit'),
+        ).toBe(PlatformEnum.REDDIT);
+      });
+
+      it('should identify np.reddit.com', () => {
+        expect(
+          SocialUtil.identifyPlatform('https://np.reddit.com/r/subreddit'),
+        ).toBe(PlatformEnum.REDDIT);
+      });
+    });
+
+    describe('Twitch', () => {
+      it('should identify twitch.tv', () => {
+        expect(SocialUtil.identifyPlatform('https://twitch.tv/channel')).toBe(
+          PlatformEnum.TWITCH,
+        );
+      });
+    });
+
+    describe('Unknown platforms', () => {
+      it('should return UNKNOWN for unrecognized domains', () => {
+        expect(SocialUtil.identifyPlatform('https://unknown.com/user')).toBe(
+          PlatformEnum.UNKNOWN,
+        );
+      });
+
+      it('should return UNKNOWN for invalid URLs', () => {
+        expect(SocialUtil.identifyPlatform('not-a-url')).toBe(
+          PlatformEnum.UNKNOWN,
+        );
+      });
+
+      it('should return UNKNOWN for empty string', () => {
+        expect(SocialUtil.identifyPlatform('')).toBe(PlatformEnum.UNKNOWN);
+      });
+
+      it('should return UNKNOWN for null/undefined', () => {
+        expect(SocialUtil.identifyPlatform(null as any)).toBe(
+          PlatformEnum.UNKNOWN,
+        );
+        expect(SocialUtil.identifyPlatform(undefined as any)).toBe(
+          PlatformEnum.UNKNOWN,
+        );
+      });
+    });
+
+    describe('Case insensitivity', () => {
+      it('should handle uppercase domains', () => {
+        expect(SocialUtil.identifyPlatform('https://GITHUB.COM/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+
+      it('should handle mixed case domains', () => {
+        expect(SocialUtil.identifyPlatform('https://GitHub.Com/user')).toBe(
+          PlatformEnum.GITHUB,
+        );
+      });
+    });
+  });
+
+  describe('extractHandle', () => {
+    it('should extract handle from GitHub URL', () => {
+      expect(SocialUtil.extractHandle('https://github.com/octocat')).toBe(
+        'octocat',
+      );
+    });
+
+    it('should extract handle from Twitter URL', () => {
+      expect(SocialUtil.extractHandle('https://twitter.com/user')).toBe(
+        'user',
+      );
+    });
+
+    it('should extract handle from Discord invite URL', () => {
+      expect(SocialUtil.extractHandle('https://discord.gg/abc123')).toBe(
+        'abc123',
+      );
+    });
+
+    it('should extract handle from LinkedIn URL', () => {
+      expect(SocialUtil.extractHandle('https://linkedin.com/in/username')).toBe(
+        'username',
+      );
+    });
+
+    it('should extract handle from Instagram URL', () => {
+      expect(SocialUtil.extractHandle('https://instagram.com/user')).toBe(
+        'user',
+      );
+    });
+
+    it('should return null for non-handle paths', () => {
+      expect(SocialUtil.extractHandle('https://twitter.com/share')).toBeNull();
+      expect(
+        SocialUtil.extractHandle('https://twitter.com/hashtag/test'),
+      ).toBeNull();
+    });
+
+    it('should return null for invalid URLs', () => {
+      expect(SocialUtil.extractHandle('not-a-url')).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      expect(SocialUtil.extractHandle('')).toBeNull();
+    });
+
+    it('should handle URLs without protocol', () => {
+      expect(SocialUtil.extractHandle('github.com/octocat')).toBe('octocat');
+    });
+  });
+
+  describe('getIconName', () => {
+    it('should return github icon name', () => {
+      expect(SocialUtil.getIconName(PlatformEnum.GITHUB)).toBe('github');
+    });
+
+    it('should return twitter icon name', () => {
+      expect(SocialUtil.getIconName(PlatformEnum.TWITTER)).toBe('twitter');
+    });
+
+    it('should return discord icon name', () => {
+      expect(SocialUtil.getIconName(PlatformEnum.DISCORD)).toBe('discord');
+    });
+
+    it('should return link icon name for unknown', () => {
+      expect(SocialUtil.getIconName(PlatformEnum.UNKNOWN)).toBe('link');
+    });
+  });
+
+  describe('enrichUrl', () => {
+    it('should enrich GitHub URL', () => {
+      const result = SocialUtil.enrichUrl('https://github.com/octocat');
+      expect(result).toEqual({
+        url: 'https://github.com/octocat',
+        platform: PlatformEnum.GITHUB,
+        iconName: 'github',
+        handle: 'octocat',
+      });
+    });
+
+    it('should enrich Twitter URL', () => {
+      const result = SocialUtil.enrichUrl('https://twitter.com/user');
+      expect(result).toEqual({
+        url: 'https://twitter.com/user',
+        platform: PlatformEnum.TWITTER,
+        iconName: 'twitter',
+        handle: 'user',
+      });
+    });
+
+    it('should enrich Discord URL', () => {
+      const result = SocialUtil.enrichUrl('https://discord.gg/abc123');
+      expect(result).toEqual({
+        url: 'https://discord.gg/abc123',
+        platform: PlatformEnum.DISCORD,
+        iconName: 'discord',
+        handle: 'abc123',
+      });
+    });
+
+    it('should enrich unknown URL', () => {
+      const result = SocialUtil.enrichUrl('https://example.com/user');
+      expect(result).toEqual({
+        url: 'https://example.com/user',
+        platform: PlatformEnum.UNKNOWN,
+        iconName: 'link',
+        handle: 'user',
+      });
+    });
+  });
+});

--- a/backend/src/common/utils/social.util.ts
+++ b/backend/src/common/utils/social.util.ts
@@ -1,0 +1,277 @@
+/**
+ * Social platform identification utility
+ * Identifies social platforms from URLs for enriching user profiles with icon metadata
+ */
+
+export enum PlatformEnum {
+  GITHUB = 'github',
+  TWITTER = 'twitter',
+  DISCORD = 'discord',
+  LINKEDIN = 'linkedin',
+  YOUTUBE = 'youtube',
+  INSTAGRAM = 'instagram',
+  FACEBOOK = 'facebook',
+  TIKTOK = 'tiktok',
+  REDDIT = 'reddit',
+  TWITCH = 'twitch',
+  UNKNOWN = 'unknown',
+}
+
+interface PlatformPattern {
+  platform: PlatformEnum;
+  domainPatterns: RegExp[];
+}
+
+const PLATFORM_PATTERNS: PlatformPattern[] = [
+  {
+    platform: PlatformEnum.GITHUB,
+    domainPatterns: [
+      /^(?:www\.)?github\.com$/i,
+      /^(?:[\w-]+\.)?github\.io$/i,
+      /^gist\.github\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.TWITTER,
+    domainPatterns: [
+      /^(?:www\.)?twitter\.com$/i,
+      /^(?:www\.)?x\.com$/i,
+      /^mobile\.twitter\.com$/i,
+      /^mobile\.x\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.DISCORD,
+    domainPatterns: [
+      /^(?:www\.)?discord\.gg$/i,
+      /^(?:www\.)?discord\.com$/i,
+      /^(?:www\.)?discordapp\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.LINKEDIN,
+    domainPatterns: [
+      /^(?:www\.)?linkedin\.com$/i,
+      /^(?:www\.)?lnkd\.in$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.YOUTUBE,
+    domainPatterns: [
+      /^(?:www\.)?youtube\.com$/i,
+      /^(?:www\.)?youtu\.be$/i,
+      /^m\.youtube\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.INSTAGRAM,
+    domainPatterns: [
+      /^(?:www\.)?instagram\.com$/i,
+      /^(?:www\.)?instagr\.am$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.FACEBOOK,
+    domainPatterns: [
+      /^(?:www\.)?facebook\.com$/i,
+      /^(?:www\.)?fb\.com$/i,
+      /^(?:www\.)?fb\.me$/i,
+      /^m\.facebook\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.TIKTOK,
+    domainPatterns: [
+      /^(?:www\.)?tiktok\.com$/i,
+      /^(?:www\.)?vm\.tiktok\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.REDDIT,
+    domainPatterns: [
+      /^(?:www\.)?reddit\.com$/i,
+      /^(?:www\.)?redd\.it$/i,
+      /^old\.reddit\.com$/i,
+      /^np\.reddit\.com$/i,
+    ],
+  },
+  {
+    platform: PlatformEnum.TWITCH,
+    domainPatterns: [
+      /^(?:www\.)?twitch\.tv$/i,
+      /^(?:www\.)?twitch\.tech$/i,
+    ],
+  },
+];
+
+export class SocialUtil {
+  /**
+   * Identifies the social platform from a given URL
+   * @param url - The URL to identify
+   * @returns The identified platform enum value
+   *
+   * @example
+   * SocialUtil.identifyPlatform('https://github.com/user') // returns PlatformEnum.GITHUB
+   * SocialUtil.identifyPlatform('https://twitter.com/user') // returns PlatformEnum.TWITTER
+   * SocialUtil.identifyPlatform('https://x.com/user') // returns PlatformEnum.TWITTER
+   * SocialUtil.identifyPlatform('https://discord.gg/invite') // returns PlatformEnum.DISCORD
+   * SocialUtil.identifyPlatform('https://unknown.com') // returns PlatformEnum.UNKNOWN
+   */
+  static identifyPlatform(url: string): PlatformEnum {
+    if (!url || typeof url !== 'string') {
+      return PlatformEnum.UNKNOWN;
+    }
+
+    try {
+      // Add protocol if missing for URL parsing
+      let normalizedUrl = url.trim();
+      if (!normalizedUrl.match(/^https?:\/\//i)) {
+        normalizedUrl = 'https://' + normalizedUrl;
+      }
+
+      const parsedUrl = new URL(normalizedUrl);
+      const hostname = parsedUrl.hostname.toLowerCase();
+
+      for (const { platform, domainPatterns } of PLATFORM_PATTERNS) {
+        for (const pattern of domainPatterns) {
+          if (pattern.test(hostname)) {
+            return platform;
+          }
+        }
+      }
+
+      return PlatformEnum.UNKNOWN;
+    } catch {
+      // Invalid URL
+      return PlatformEnum.UNKNOWN;
+    }
+  }
+
+  /**
+   * Extracts the handle/username from a social media URL
+   * @param url - The social media URL
+   * @returns The extracted handle or null if not found
+   *
+   * @example
+   * SocialUtil.extractHandle('https://github.com/octocat') // returns 'octocat'
+   * SocialUtil.extractHandle('https://twitter.com/user') // returns 'user'
+   */
+  static extractHandle(url: string): string | null {
+    if (!url || typeof url !== 'string') {
+      return null;
+    }
+
+    try {
+      let normalizedUrl = url.trim();
+      if (!normalizedUrl.match(/^https?:\/\//i)) {
+        normalizedUrl = 'https://' + normalizedUrl;
+      }
+
+      const parsedUrl = new URL(normalizedUrl);
+      const pathname = parsedUrl.pathname;
+      const platform = this.identifyPlatform(url);
+
+      // Remove leading/trailing slashes and get path segments
+      const segments = pathname.replace(/^\/+|\/+$/g, '').split('/');
+
+      // Platform-specific handle extraction
+      switch (platform) {
+        case PlatformEnum.LINKEDIN:
+          // LinkedIn URLs: linkedin.com/in/username
+          if (segments.length >= 2 && segments[0] === 'in') {
+            return segments[1];
+          }
+          break;
+        case PlatformEnum.REDDIT:
+          // Reddit URLs: reddit.com/u/username or reddit.com/user/username
+          if (
+            segments.length >= 2 &&
+            (segments[0] === 'u' || segments[0] === 'user')
+          ) {
+            return segments[1];
+          }
+          break;
+        case PlatformEnum.YOUTUBE:
+          // YouTube URLs: youtube.com/@username or youtube.com/c/username
+          if (segments.length >= 1) {
+            if (segments[0].startsWith('@')) {
+              return segments[0].substring(1);
+            }
+            if (
+              segments.length >= 2 &&
+              (segments[0] === 'c' || segments[0] === 'channel')
+            ) {
+              return segments[1];
+            }
+          }
+          break;
+      }
+
+      // Default: get first path segment
+      if (segments.length > 0 && segments[0]) {
+        // Filter out common non-handle paths
+        const nonHandlePaths = [
+          'share',
+          'intent',
+          'hashtag',
+          'search',
+          'explore',
+          'settings',
+        ];
+        if (!nonHandlePaths.includes(segments[0].toLowerCase())) {
+          return segments[0];
+        }
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Gets the icon identifier for a platform (for frontend icon mapping)
+   * @param platform - The platform enum value
+   * @returns The icon identifier string
+   */
+  static getIconName(platform: PlatformEnum): string {
+    const iconMap: Record<PlatformEnum, string> = {
+      [PlatformEnum.GITHUB]: 'github',
+      [PlatformEnum.TWITTER]: 'twitter',
+      [PlatformEnum.DISCORD]: 'discord',
+      [PlatformEnum.LINKEDIN]: 'linkedin',
+      [PlatformEnum.YOUTUBE]: 'youtube',
+      [PlatformEnum.INSTAGRAM]: 'instagram',
+      [PlatformEnum.FACEBOOK]: 'facebook',
+      [PlatformEnum.TIKTOK]: 'tiktok',
+      [PlatformEnum.REDDIT]: 'reddit',
+      [PlatformEnum.TWITCH]: 'twitch',
+      [PlatformEnum.UNKNOWN]: 'link',
+    };
+
+    return iconMap[platform] || 'link';
+  }
+
+  /**
+   * Enriches a URL with platform metadata
+   * @param url - The social media URL
+   * @returns Object containing platform, icon name, and extracted handle
+   */
+  static enrichUrl(url: string): {
+    url: string;
+    platform: PlatformEnum;
+    iconName: string;
+    handle: string | null;
+  } {
+    const platform = this.identifyPlatform(url);
+    const iconName = this.getIconName(platform);
+    const handle = this.extractHandle(url);
+
+    return {
+      url,
+      platform,
+      iconName,
+      handle,
+    };
+  }
+}

--- a/backend/src/guild/dto/approve-invite.dto.ts
+++ b/backend/src/guild/dto/approve-invite.dto.ts
@@ -1,6 +1,11 @@
 import { IsString, IsOptional } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ApproveInviteDto {
+  @ApiPropertyOptional({
+    description: 'Invitation token for guild membership approval',
+    example: 'inv_abc123def456',
+  })
   @IsOptional()
   @IsString()
   token?: string;

--- a/backend/src/guild/dto/create-guild.dto.ts
+++ b/backend/src/guild/dto/create-guild.dto.ts
@@ -6,14 +6,27 @@ import {
   IsObject,
   Matches,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 
 export class CreateGuildDto {
+  @ApiProperty({
+    description: 'Name of the guild (1-100 characters)',
+    example: 'Stellar Builders Guild',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsString()
   @MaxLength(100)
   @MinLength(1)
   name!: string;
 
+  @ApiPropertyOptional({
+    description:
+      'URL-friendly identifier for the guild (lowercase letters, numbers, and hyphens only). Auto-generated from name if not provided.',
+    example: 'stellar-builders-guild',
+    pattern: '^[a-z0-9-]+$',
+  })
   @IsOptional()
   @IsString()
   @MinLength(1)
@@ -24,11 +37,20 @@ export class CreateGuildDto {
   })
   slug?: string;
 
+  @ApiPropertyOptional({
+    description: 'Guild description explaining its purpose and community',
+    example: 'A guild for developers building on the Stellar network...',
+    maxLength: 1000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(1000)
   description?: string;
 
+  @ApiPropertyOptional({
+    description: 'Guild configuration settings object',
+    example: { visibility: 'public', allowJoinRequests: true },
+  })
   @IsOptional()
   @IsObject()
   settings?: any;

--- a/backend/src/guild/dto/guild-details.dto.ts
+++ b/backend/src/guild/dto/guild-details.dto.ts
@@ -1,25 +1,104 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
 export class GuildDetailsDto {
+  @ApiProperty({
+    description: 'Unique identifier for the guild',
+    example: 'clx123abc456',
+  })
   id!: string;
+
+  @ApiProperty({
+    description: 'Date and time when the guild was created',
+    example: '2026-01-15T10:30:00.000Z',
+  })
   createdAt!: Date;
+
+  @ApiProperty({
+    description: 'Date and time when the guild was last updated',
+    example: '2026-04-10T14:20:00.000Z',
+  })
   updatedAt!: Date;
+
+  @ApiProperty({
+    description: 'Name of the guild',
+    example: 'Stellar Builders Guild',
+  })
   name!: string;
+
+  @ApiProperty({
+    description: 'URL-friendly identifier for the guild',
+    example: 'stellar-builders-guild',
+  })
   slug!: string;
+
+  @ApiPropertyOptional({
+    description: 'Guild description',
+    example: 'A community for Stellar developers',
+  })
   description?: string;
+
+  @ApiPropertyOptional({
+    description: 'URL to the guild avatar image',
+    example: 'https://example.com/avatars/guild123.png',
+  })
   avatarUrl?: string;
+
+  @ApiPropertyOptional({
+    description: 'URL to the guild banner image',
+    example: 'https://example.com/banners/guild123.png',
+  })
   bannerUrl?: string;
+
+  @ApiProperty({
+    description: 'User ID of the guild owner',
+    example: 'clx456def789',
+  })
   ownerId!: string;
+
+  @ApiPropertyOptional({
+    description: 'Guild configuration settings',
+    example: { visibility: 'public', allowJoinRequests: true },
+  })
   settings?: any;
+
+  @ApiProperty({
+    description: 'Number of members in the guild',
+    example: 42,
+  })
   memberCount!: number;
+
+  @ApiProperty({
+    description: 'Whether the guild is currently active',
+    example: true,
+  })
   isActive!: boolean;
 
-  // Counts
+  @ApiPropertyOptional({
+    description: 'Count of related entities',
+    example: { memberships: 42, bounties: 15 },
+  })
   _count?: {
     memberships?: number;
     bounties?: number;
   };
 
-  // Relations included in existing implementation
+  @ApiPropertyOptional({
+    description: 'Guild memberships/members list',
+    type: 'array',
+    items: { type: 'object' },
+  })
   memberships?: any[];
+
+  @ApiPropertyOptional({
+    description: 'Guild owner information',
+    type: 'object',
+  })
   owner?: any;
+
+  @ApiPropertyOptional({
+    description: 'Bounties associated with this guild',
+    type: 'array',
+    items: { type: 'object' },
+  })
   bounties?: any[];
 }

--- a/backend/src/guild/dto/guild-list.dto.ts
+++ b/backend/src/guild/dto/guild-list.dto.ts
@@ -1,13 +1,26 @@
 import { IsOptional, IsInt, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 export class GuildListDto {
+  @ApiPropertyOptional({
+    description: 'Page number for pagination (0-indexed)',
+    example: 0,
+    minimum: 0,
+    default: 0,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(0)
   page?: number = 0;
 
+  @ApiPropertyOptional({
+    description: 'Number of guilds to return per page',
+    example: 20,
+    minimum: 1,
+    default: 20,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/backend/src/guild/dto/invite-member.dto.ts
+++ b/backend/src/guild/dto/invite-member.dto.ts
@@ -1,9 +1,18 @@
 import { IsString, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class InviteMemberDto {
+  @ApiProperty({
+    description: 'User ID to invite to the guild',
+    example: 'clx789ghi012',
+  })
   @IsString()
   userId!: string;
 
+  @ApiPropertyOptional({
+    description: 'Role to assign to the invited member (e.g., MEMBER, ADMIN)',
+    example: 'MEMBER',
+  })
   @IsOptional()
   @IsString()
   role?: string; // GuildRole

--- a/backend/src/guild/dto/search-guild.dto.ts
+++ b/backend/src/guild/dto/search-guild.dto.ts
@@ -1,17 +1,34 @@
 import { IsOptional, IsString, IsInt, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 export class SearchGuildDto {
+  @ApiPropertyOptional({
+    description: 'Search query string to filter guilds by name or description',
+    example: 'stellar',
+  })
   @IsOptional()
   @IsString()
   q?: string;
 
+  @ApiPropertyOptional({
+    description: 'Page number for pagination (0-indexed)',
+    example: 0,
+    minimum: 0,
+    default: 0,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(0)
   page?: number = 0;
 
+  @ApiPropertyOptional({
+    description: 'Number of results per page',
+    example: 20,
+    minimum: 1,
+    default: 20,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/backend/src/guild/dto/update-guild.dto.ts
+++ b/backend/src/guild/dto/update-guild.dto.ts
@@ -6,15 +6,28 @@ import {
   IsObject,
   Matches,
 } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 
 export class UpdateGuildDto {
+  @ApiPropertyOptional({
+    description: 'Updated name of the guild (1-100 characters)',
+    example: 'Stellar Builders Guild v2',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsOptional()
   @IsString()
   @MinLength(1)
   @MaxLength(100)
   name?: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Updated URL-friendly identifier (lowercase letters, numbers, and hyphens only)',
+    example: 'stellar-builders-guild-v2',
+    pattern: '^[a-z0-9-]+$',
+  })
   @IsOptional()
   @IsString()
   @MinLength(1)
@@ -25,11 +38,20 @@ export class UpdateGuildDto {
   })
   slug?: string;
 
+  @ApiPropertyOptional({
+    description: 'Updated guild description',
+    example: 'An improved guild for developers building on Stellar...',
+    maxLength: 1000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(1000)
   description?: string;
 
+  @ApiPropertyOptional({
+    description: 'Updated guild configuration settings',
+    example: { visibility: 'private', allowJoinRequests: false },
+  })
   @IsOptional()
   @IsObject()
   settings?: any;

--- a/backend/src/guild/guild.settings.spec.ts
+++ b/backend/src/guild/guild.settings.spec.ts
@@ -30,4 +30,64 @@ describe('Guild settings validation', () => {
       BadRequestException,
     );
   });
+
+  // Treasury settings tests
+  it('validates and sets lowBalanceThreshold', () => {
+    const input = { lowBalanceThreshold: 50 };
+    const out = validateAndNormalizeSettings(input);
+    expect(out.lowBalanceThreshold).toBe(50);
+  });
+
+  it('uses default lowBalanceThreshold when not provided', () => {
+    const out = validateAndNormalizeSettings({});
+    expect(out.lowBalanceThreshold).toBe(DEFAULT_GUILD_SETTINGS.lowBalanceThreshold);
+  });
+
+  it('throws on negative lowBalanceThreshold', () => {
+    expect(() =>
+      validateAndNormalizeSettings({ lowBalanceThreshold: -10 }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('throws on non-numeric lowBalanceThreshold', () => {
+    expect(() =>
+      validateAndNormalizeSettings({ lowBalanceThreshold: 'abc' }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('validates lowBalanceAlertEnabled', () => {
+    const input = { lowBalanceAlertEnabled: false };
+    const out = validateAndNormalizeSettings(input);
+    expect(out.lowBalanceAlertEnabled).toBe(false);
+  });
+
+  it('throws on non-boolean lowBalanceAlertEnabled', () => {
+    expect(() =>
+      validateAndNormalizeSettings({ lowBalanceAlertEnabled: 'true' }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('validates treasuryAddress', () => {
+    const input = { treasuryAddress: 'GABC123...' };
+    const out = validateAndNormalizeSettings(input);
+    expect(out.treasuryAddress).toBe('GABC123...');
+  });
+
+  it('allows null treasuryAddress', () => {
+    const input = { treasuryAddress: null };
+    const out = validateAndNormalizeSettings(input);
+    expect(out.treasuryAddress).toBeNull();
+  });
+
+  it('validates all treasury settings together', () => {
+    const input = {
+      lowBalanceThreshold: 200,
+      lowBalanceAlertEnabled: true,
+      treasuryAddress: 'GDEFGHI...',
+    };
+    const out = validateAndNormalizeSettings(input);
+    expect(out.lowBalanceThreshold).toBe(200);
+    expect(out.lowBalanceAlertEnabled).toBe(true);
+    expect(out.treasuryAddress).toBe('GDEFGHI...');
+  });
 });

--- a/backend/src/guild/guild.settings.ts
+++ b/backend/src/guild/guild.settings.ts
@@ -5,6 +5,10 @@ export type GuildSettings = {
   requireApproval?: boolean; // joining requires approval
   discoverable?: boolean; // shows up in search
   maxMembers?: number | null;
+  // Treasury settings
+  lowBalanceThreshold?: number; // XLM threshold for low balance alerts
+  lowBalanceAlertEnabled?: boolean; // whether low balance alerts are enabled
+  treasuryAddress?: string; // Stellar treasury account address (mocked)
 };
 
 export const DEFAULT_GUILD_SETTINGS: Required<GuildSettings> = {
@@ -12,6 +16,9 @@ export const DEFAULT_GUILD_SETTINGS: Required<GuildSettings> = {
   requireApproval: false,
   discoverable: true,
   maxMembers: null,
+  lowBalanceThreshold: 100, // Default: alert when balance drops below 100 XLM
+  lowBalanceAlertEnabled: true,
+  treasuryAddress: null as any,
 };
 
 export function validateAndNormalizeSettings(
@@ -50,6 +57,30 @@ export function validateAndNormalizeSettings(
         'maxMembers must be a positive number or null',
       );
     out.maxMembers = input.maxMembers;
+  }
+
+  // Treasury settings validation
+  if ('lowBalanceThreshold' in input) {
+    if (
+      typeof input.lowBalanceThreshold !== 'number' ||
+      input.lowBalanceThreshold < 0
+    )
+      throw new BadRequestException(
+        'lowBalanceThreshold must be a non-negative number',
+      );
+    out.lowBalanceThreshold = input.lowBalanceThreshold;
+  }
+
+  if ('lowBalanceAlertEnabled' in input) {
+    if (typeof input.lowBalanceAlertEnabled !== 'boolean')
+      throw new BadRequestException('lowBalanceAlertEnabled must be boolean');
+    out.lowBalanceAlertEnabled = input.lowBalanceAlertEnabled;
+  }
+
+  if ('treasuryAddress' in input) {
+    if (input.treasuryAddress !== null && typeof input.treasuryAddress !== 'string')
+      throw new BadRequestException('treasuryAddress must be a string or null');
+    out.treasuryAddress = input.treasuryAddress;
   }
 
   return out;

--- a/backend/src/mailer/mailer.service.ts
+++ b/backend/src/mailer/mailer.service.ts
@@ -70,4 +70,42 @@ If you weren't expecting this invite, ignore this message.`;
       this.logger.log(`Revoke (not sent) -> to: ${to}, subject: ${subject}`);
     }
   }
+
+  async sendTreasuryAlertEmail(
+    to: string,
+    guildName: string,
+    alert: {
+      currentBalance: { xlm: number; usdc: number };
+      threshold: number;
+      detectedAt: Date;
+    },
+  ) {
+    const from =
+      process.env.MAIL_FROM ||
+      process.env.SMTP_USER ||
+      'no-reply@stellar-guilds.local';
+    const subject = `[Stellar Guilds] Low Treasury Balance Alert - ${guildName}`;
+    const text = `Low Treasury Balance Alert
+
+Guild: ${guildName}
+Current Balance:
+  - XLM: ${alert.currentBalance.xlm}
+  - USDC: ${alert.currentBalance.usdc}
+Threshold: ${alert.threshold} XLM equivalent
+Detected at: ${alert.detectedAt.toISOString()}
+
+Your guild's treasury balance has fallen below the configured threshold.
+Please consider depositing funds to ensure bounties and other guild operations can continue.
+
+This is an automated alert from Stellar Guilds.`;
+
+    if (this.transporter) {
+      await this.transporter.sendMail({ from, to, subject, text });
+      this.logger.log(`Treasury alert email sent to ${to}`);
+    } else {
+      this.logger.log(
+        `Treasury alert (not sent) -> to: ${to}, subject: ${subject}`,
+      );
+    }
+  }
 }

--- a/backend/src/queue/queue.constants.ts
+++ b/backend/src/queue/queue.constants.ts
@@ -16,6 +16,11 @@ export const QUEUE_NAMES = {
    * Dummy queue for testing/proof of concept
    */
   DUMMY: 'dummy',
+
+  /**
+   * Queue for treasury monitoring and balance alerts
+   */
+  TREASURY_MONITOR: 'treasury-monitor',
 } as const;
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];

--- a/backend/src/queue/queue.module.ts
+++ b/backend/src/queue/queue.module.ts
@@ -46,6 +46,9 @@ import { QueueController } from './queue.controller';
       {
         name: QUEUE_NAMES.ON_CHAIN_EVENTS,
       },
+      {
+        name: QUEUE_NAMES.TREASURY_MONITOR,
+      },
     ),
   ],
   controllers: [QueueController],

--- a/backend/src/treasury/index.ts
+++ b/backend/src/treasury/index.ts
@@ -1,0 +1,2 @@
+export * from './treasury.module';
+export * from './treasury-monitor.service';

--- a/backend/src/treasury/processors/treasury.processor.ts
+++ b/backend/src/treasury/processors/treasury.processor.ts
@@ -1,0 +1,54 @@
+import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { TreasuryMonitorService } from '../treasury-monitor.service';
+import { QUEUE_NAMES } from '../../queue/queue.constants';
+
+export interface TreasuryCheckJobData {
+  triggeredAt: Date;
+}
+
+@Processor(QUEUE_NAMES.TREASURY_MONITOR)
+export class TreasuryProcessor extends WorkerHost {
+  private readonly logger = new Logger(TreasuryProcessor.name);
+
+  constructor(private readonly treasuryMonitor: TreasuryMonitorService) {
+    super();
+  }
+
+  async process(job: Job<TreasuryCheckJobData>): Promise<void> {
+    this.logger.log(
+      `Processing treasury check job ${job.id} triggered at ${job.data.triggeredAt}`,
+    );
+
+    try {
+      const alerts = await this.treasuryMonitor.checkAllGuilds();
+      
+      this.logger.log(
+        `Treasury check completed. ${alerts.length} alerts triggered.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Treasury check job ${job.id} failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  @OnWorkerEvent('active')
+  onActive(job: Job<TreasuryCheckJobData>) {
+    this.logger.debug(`Treasury check job ${job.id} is now active`);
+  }
+
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job<TreasuryCheckJobData>) {
+    this.logger.log(`Treasury check job ${job.id} completed successfully`);
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job<TreasuryCheckJobData>, error: Error) {
+    this.logger.error(
+      `Treasury check job ${job.id} failed: ${error.message}`,
+    );
+  }
+}

--- a/backend/src/treasury/treasury-monitor.service.spec.ts
+++ b/backend/src/treasury/treasury-monitor.service.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TreasuryMonitorService } from './treasury-monitor.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { MailerService } from '../mailer/mailer.service';
+
+describe('TreasuryMonitorService', () => {
+  let service: TreasuryMonitorService;
+  let prismaService: PrismaService;
+  let mailerService: MailerService;
+
+  const mockPrismaService = {
+    guild: {
+      findMany: jest.fn(),
+    },
+    notification: {
+      create: jest.fn(),
+    },
+  };
+
+  const mockMailerService = {
+    sendTreasuryAlertEmail: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TreasuryMonitorService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: MailerService, useValue: mockMailerService },
+      ],
+    }).compile();
+
+    service = module.get<TreasuryMonitorService>(TreasuryMonitorService);
+    prismaService = module.get<PrismaService>(PrismaService);
+    mailerService = module.get<MailerService>(MailerService);
+
+    jest.clearAllMocks();
+  });
+
+  describe('getTreasuryBalance', () => {
+    it('returns zero balance when address is null', async () => {
+      const balance = await service.getTreasuryBalance(null);
+      expect(balance).toEqual({ xlm: 0, usdc: 0 });
+    });
+
+    it('returns mock balance for valid address', async () => {
+      const balance = await service.getTreasuryBalance('GABC123...');
+      expect(balance.xlm).toBeGreaterThan(0);
+      expect(balance.usdc).toBeGreaterThan(0);
+    });
+
+    it('returns consistent balance for same address', async () => {
+      const address = 'GABC123...';
+      const balance1 = await service.getTreasuryBalance(address);
+      const balance2 = await service.getTreasuryBalance(address);
+      expect(balance1).toEqual(balance2);
+    });
+  });
+
+  describe('checkGuildBalance', () => {
+    it('returns null when alerts are disabled', async () => {
+      const alert = await service.checkGuildBalance(
+        'guild-1',
+        'Test Guild',
+        { lowBalanceAlertEnabled: false, lowBalanceThreshold: 100, treasuryAddress: null },
+        { id: 'owner-1', email: 'owner@test.com', username: 'owner' },
+      );
+      expect(alert).toBeNull();
+    });
+
+    it('returns alert when balance is below threshold', async () => {
+      const alert = await service.checkGuildBalance(
+        'guild-1',
+        'Test Guild',
+        { lowBalanceAlertEnabled: true, lowBalanceThreshold: 1000, treasuryAddress: 'GABC...' },
+        { id: 'owner-1', email: 'owner@test.com', username: 'owner' },
+      );
+      // Since mock balance is random, this test verifies the logic structure
+      expect(alert === null || (alert.guildId === 'guild-1' && alert.guildName === 'Test Guild')).toBeTruthy();
+    });
+  });
+
+  describe('checkAllGuilds', () => {
+    it('processes all active guilds', async () => {
+      mockPrismaService.guild.findMany.mockResolvedValue([
+        {
+          id: 'guild-1',
+          name: 'Guild One',
+          settings: { lowBalanceThreshold: 100, lowBalanceAlertEnabled: true, treasuryAddress: 'GABC...' },
+          ownerId: 'owner-1',
+          owner: { id: 'owner-1', email: 'owner1@test.com', username: 'owner1' },
+          memberships: [],
+        },
+        {
+          id: 'guild-2',
+          name: 'Guild Two',
+          settings: { lowBalanceThreshold: 100, lowBalanceAlertEnabled: true, treasuryAddress: 'GDEF...' },
+          ownerId: 'owner-2',
+          owner: { id: 'owner-2', email: 'owner2@test.com', username: 'owner2' },
+          memberships: [],
+        },
+      ]);
+
+      const alerts = await service.checkAllGuilds();
+      
+      expect(mockPrismaService.guild.findMany).toHaveBeenCalled();
+      expect(Array.isArray(alerts)).toBeTruthy();
+    });
+
+    it('skips guilds with alerts disabled', async () => {
+      mockPrismaService.guild.findMany.mockResolvedValue([
+        {
+          id: 'guild-1',
+          name: 'Guild One',
+          settings: { lowBalanceAlertEnabled: false },
+          ownerId: 'owner-1',
+          owner: { id: 'owner-1', email: 'owner1@test.com', username: 'owner1' },
+          memberships: [],
+        },
+      ]);
+
+      const alerts = await service.checkAllGuilds();
+      expect(alerts).toHaveLength(0);
+    });
+  });
+});

--- a/backend/src/treasury/treasury-monitor.service.ts
+++ b/backend/src/treasury/treasury-monitor.service.ts
@@ -1,0 +1,267 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { MailerService } from '../mailer/mailer.service';
+import { DEFAULT_GUILD_SETTINGS, GuildSettings } from '../guild/guild.settings';
+
+export interface TreasuryBalance {
+  xlm: number;
+  usdc: number;
+}
+
+export interface LowBalanceAlert {
+  guildId: string;
+  guildName: string;
+  currentBalance: TreasuryBalance;
+  threshold: number;
+  detectedAt: Date;
+}
+
+@Injectable()
+export class TreasuryMonitorService {
+  private readonly logger = new Logger(TreasuryMonitorService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly mailer: MailerService,
+  ) {}
+
+  /**
+   * Mock implementation of on-chain balance checking.
+   * In production, this would call the Stellar Horizon API.
+   */
+  async getTreasuryBalance(treasuryAddress: string | null): Promise<TreasuryBalance> {
+    // Mock: return a random balance for testing purposes
+    // In production, this would query the Stellar network
+    if (!treasuryAddress) {
+      return { xlm: 0, usdc: 0 };
+    }
+
+    // Simulate varying balances for demonstration
+    // Use a deterministic hash of the address to get consistent mock values
+    const hash = this.simpleHash(treasuryAddress);
+    const xlm = (hash % 500) + 10; // 10-519 XLM
+    const usdc = (hash % 200) + 5; // 5-204 USDC
+
+    this.logger.debug(
+      `Mock balance for ${treasuryAddress}: ${xlm} XLM, ${usdc} USDC`,
+    );
+
+    return { xlm, usdc };
+  }
+
+  /**
+   * Simple hash function for generating deterministic mock balances
+   */
+  private simpleHash(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+    return Math.abs(hash);
+  }
+
+  /**
+   * Check all guilds for low treasury balance and trigger alerts
+   */
+  async checkAllGuilds(): Promise<LowBalanceAlert[]> {
+    this.logger.log('Starting treasury balance check for all guilds...');
+    const alerts: LowBalanceAlert[] = [];
+
+    // Fetch all active guilds with their settings
+    const guilds = await this.prisma.guild.findMany({
+      where: { isActive: true, deletedAt: null },
+      include: {
+        owner: true,
+        memberships: {
+          where: {
+            role: { in: ['ADMIN', 'OWNER'] },
+            status: 'APPROVED',
+          },
+          include: { user: true },
+        },
+      },
+    });
+
+    this.logger.log(`Found ${guilds.length} active guilds to check`);
+
+    for (const guild of guilds) {
+      try {
+        const settings = this.parseGuildSettings(guild.settings);
+        const alert = await this.checkGuildBalance(guild.id, guild.name, settings, guild.owner);
+
+        if (alert) {
+          alerts.push(alert);
+          await this.triggerAlert(guild, alert, settings);
+        }
+      } catch (error) {
+        this.logger.error(
+          `Error checking treasury for guild ${guild.id}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Treasury check complete. ${alerts.length} low balance alerts triggered.`,
+    );
+    return alerts;
+  }
+
+  /**
+   * Check a single guild's balance against its threshold
+   */
+  async checkGuildBalance(
+    guildId: string,
+    guildName: string,
+    settings: GuildSettings,
+    owner: { id: string; email: string; username: string },
+  ): Promise<LowBalanceAlert | null> {
+    // Skip if alerts are disabled
+    if (settings.lowBalanceAlertEnabled === false) {
+      this.logger.debug(`Low balance alerts disabled for guild ${guildId}`);
+      return null;
+    }
+
+    // Get threshold (default if not set)
+    const threshold =
+      settings.lowBalanceThreshold ?? DEFAULT_GUILD_SETTINGS.lowBalanceThreshold;
+
+    // Get balance (mocked)
+    const balance = await this.getTreasuryBalance(settings.treasuryAddress ?? null);
+
+    // Check if balance is below threshold
+    const totalBalance = balance.xlm + balance.usdc * 0.1; // Simplified: treat 1 USDC as 0.1 XLM equivalent
+    
+    this.logger.debug(
+      `Guild ${guildId}: balance=${totalBalance.toFixed(2)} XLM equivalent, threshold=${threshold}`,
+    );
+
+    if (totalBalance < threshold) {
+      return {
+        guildId,
+        guildName,
+        currentBalance: balance,
+        threshold,
+        detectedAt: new Date(),
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Parse guild settings from JSON, applying defaults
+   */
+  private parseGuildSettings(settingsJson: any): GuildSettings {
+    if (!settingsJson || typeof settingsJson !== 'object') {
+      return { ...DEFAULT_GUILD_SETTINGS };
+    }
+    return {
+      ...DEFAULT_GUILD_SETTINGS,
+      ...settingsJson,
+    };
+  }
+
+  /**
+   * Trigger alert: send email notification and create in-app notification
+   */
+  private async triggerAlert(
+    guild: {
+      id: string;
+      name: string;
+      ownerId: string;
+      owner: { id: string; email: string; username: string };
+      memberships: Array<{
+        userId: string;
+        user: { id: string; email: string; username: string };
+      }>;
+    },
+    alert: LowBalanceAlert,
+    settings: GuildSettings,
+  ): Promise<void> {
+    this.logger.warn(
+      `LOW BALANCE ALERT: Guild "${alert.guildName}" (${alert.guildId}) has ` +
+        `${alert.currentBalance.xlm} XLM / ${alert.currentBalance.usdc} USDC ` +
+        `(threshold: ${alert.threshold} XLM)`,
+    );
+
+    // Collect all admin/owner emails for notification
+    const adminEmails: string[] = [];
+    const adminUserIds: string[] = [];
+
+    // Add owner
+    adminEmails.push(guild.owner.email);
+    adminUserIds.push(guild.owner.id);
+
+    // Add other admins
+    for (const membership of guild.memberships) {
+      if (membership.userId !== guild.owner.id) {
+        adminEmails.push(membership.user.email);
+        adminUserIds.push(membership.userId);
+      }
+    }
+
+    // Send email alerts
+    const emailSubject = `[Stellar Guilds] Low Treasury Balance Alert - ${alert.guildName}`;
+    const emailBody = this.formatAlertEmail(alert);
+
+    for (const email of adminEmails) {
+      try {
+        await this.mailer.sendTreasuryAlertEmail(email, alert.guildName, alert);
+      } catch (error) {
+        this.logger.error(
+          `Failed to send treasury alert email to ${email}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    // Create in-app notifications for all admins
+    for (const userId of adminUserIds) {
+      try {
+        await this.prisma.notification.create({
+          data: {
+            userId,
+            message: `Low treasury balance warning for guild "${alert.guildName}": ` +
+              `${alert.currentBalance.xlm} XLM / ${alert.currentBalance.usdc} USDC remaining ` +
+              `(threshold: ${alert.threshold} XLM)`,
+            type: 'TREASURY_LOW_BALANCE',
+            metadata: {
+              guildId: alert.guildId,
+              guildName: alert.guildName,
+              xlmBalance: alert.currentBalance.xlm,
+              usdcBalance: alert.currentBalance.usdc,
+              threshold: alert.threshold,
+              detectedAt: alert.detectedAt.toISOString(),
+            },
+          },
+        });
+      } catch (error) {
+        this.logger.error(
+          `Failed to create notification for user ${userId}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Format alert email content
+   */
+  private formatAlertEmail(alert: LowBalanceAlert): string {
+    return `
+Low Treasury Balance Alert
+
+Guild: ${alert.guildName}
+Current Balance:
+  - XLM: ${alert.currentBalance.xlm}
+  - USDC: ${alert.currentBalance.usdc}
+Threshold: ${alert.threshold} XLM equivalent
+Detected at: ${alert.detectedAt.toISOString()}
+
+Your guild's treasury balance has fallen below the configured threshold.
+Please consider depositing funds to ensure bounties and other guild operations can continue.
+
+This is an automated alert from Stellar Guilds.
+    `.trim();
+  }
+}

--- a/backend/src/treasury/treasury.module.ts
+++ b/backend/src/treasury/treasury.module.ts
@@ -1,0 +1,56 @@
+import { Module, OnModuleInit, Logger } from '@nestjs/common';
+import { BullModule, InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { TreasuryMonitorService } from './treasury-monitor.service';
+import { TreasuryProcessor } from './processors/treasury.processor';
+import { PrismaModule } from '../prisma/prisma.module';
+import { MailerModule } from '../mailer/mailer.module';
+import { QUEUE_NAMES } from '../queue/queue.constants';
+
+@Module({
+  imports: [
+    PrismaModule,
+    MailerModule,
+    BullModule.registerQueue({
+      name: QUEUE_NAMES.TREASURY_MONITOR,
+    }),
+  ],
+  providers: [TreasuryMonitorService, TreasuryProcessor],
+  exports: [TreasuryMonitorService],
+})
+export class TreasuryModule implements OnModuleInit {
+  private readonly logger = new Logger(TreasuryModule.name);
+
+  constructor(
+    @InjectQueue(QUEUE_NAMES.TREASURY_MONITOR)
+    private readonly treasuryQueue: Queue,
+  ) {}
+
+  async onModuleInit() {
+    // Schedule a daily cron job at 9:00 AM UTC
+    // The cron pattern: minute hour day-of-month month day-of-week
+    // '0 9 * * *' = every day at 9:00 AM UTC
+    const cronExpression = process.env.TREASURY_CHECK_CRON || '0 9 * * *';
+
+    try {
+      await this.treasuryQueue.add(
+        'treasury-check',
+        { triggeredAt: new Date() },
+        {
+          repeat: {
+            pattern: cronExpression,
+          },
+          jobId: 'treasury-daily-check', // Prevents duplicate jobs
+        },
+      );
+
+      this.logger.log(
+        `Treasury monitoring cron job scheduled with pattern: ${cronExpression}`,
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Failed to schedule treasury cron job (Redis may not be available): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -120,6 +120,12 @@ export class UserProfileDto {
 
 // Update user profile
 export class UpdateUserDto {
+  @ApiPropertyOptional({
+    description: 'Updated first name',
+    example: 'Gabriel',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsOptional()
   @Transform(trimString)
   @IsString()
@@ -127,6 +133,12 @@ export class UpdateUserDto {
   @MaxLength(100)
   firstName?: string;
 
+  @ApiPropertyOptional({
+    description: 'Updated last name',
+    example: 'Lovelace',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsOptional()
   @Transform(trimString)
   @IsString()
@@ -134,6 +146,12 @@ export class UpdateUserDto {
   @MaxLength(100)
   lastName?: string;
 
+  @ApiPropertyOptional({
+    description: 'User biography or about section',
+    example: 'Full-stack developer passionate about blockchain technology',
+    minLength: 1,
+    maxLength: 500,
+  })
   @IsOptional()
   @Transform(trimString)
   @IsString()
@@ -141,6 +159,12 @@ export class UpdateUserDto {
   @MaxLength(500)
   bio?: string;
 
+  @ApiPropertyOptional({
+    description: 'User location',
+    example: 'San Francisco, CA',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsOptional()
   @Transform(trimString)
   @IsString()
@@ -148,6 +172,12 @@ export class UpdateUserDto {
   @MaxLength(100)
   location?: string;
 
+  @ApiPropertyOptional({
+    description: 'Extended profile biography',
+    example: 'Started coding at age 12...',
+    minLength: 1,
+    maxLength: 500,
+  })
   @IsOptional()
   @Transform(trimString)
   @IsString()
@@ -155,6 +185,11 @@ export class UpdateUserDto {
   @MaxLength(500)
   profileBio?: string;
 
+  @ApiPropertyOptional({
+    description: 'Personal or portfolio URL (must include protocol)',
+    example: 'https://myportfolio.example.com',
+    maxLength: 2048,
+  })
   @IsOptional()
   @Transform(trimString)
   @IsString()
@@ -165,6 +200,12 @@ export class UpdateUserDto {
   @MaxLength(2048)
   profileUrl?: string;
 
+  @ApiPropertyOptional({
+    description: 'Discord username/handle',
+    example: 'stellarbuilder#1234',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsOptional()
   @Transform(trimString)
   @IsString()
@@ -172,6 +213,12 @@ export class UpdateUserDto {
   @MaxLength(100)
   discordHandle?: string;
 
+  @ApiPropertyOptional({
+    description: 'Twitter/X handle',
+    example: '@stellarbuilder',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsOptional()
   @Transform(trimString)
   @IsString()
@@ -179,6 +226,12 @@ export class UpdateUserDto {
   @MaxLength(100)
   twitterHandle?: string;
 
+  @ApiPropertyOptional({
+    description: 'GitHub username',
+    example: 'stellarbuilder',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsOptional()
   @Transform(trimString)
   @IsString()
@@ -191,14 +244,29 @@ export class UpdateUserProfileDto extends UpdateUserDto {}
 
 // Change password
 export class ChangePasswordDto {
+  @ApiProperty({
+    description: 'Current password for verification',
+    example: 'OldPassword123',
+    minLength: 8,
+  })
   @IsString()
   @MinLength(8)
   currentPassword!: string;
 
+  @ApiProperty({
+    description: 'New password (minimum 8 characters)',
+    example: 'NewStrongPassword456',
+    minLength: 8,
+  })
   @IsString()
   @MinLength(8)
   newPassword!: string;
 
+  @ApiProperty({
+    description: 'Confirmation of the new password (must match newPassword)',
+    example: 'NewStrongPassword456',
+    minLength: 8,
+  })
   @IsString()
   @MinLength(8)
   confirmPassword!: string;
@@ -206,29 +274,58 @@ export class ChangePasswordDto {
 
 // Assign role to user
 export class AssignRoleDto {
+  @ApiProperty({
+    description: 'Role to assign to the user',
+    enum: UserRole,
+    example: UserRole.MODERATOR,
+  })
   @IsEnum(UserRole)
   role!: UserRole;
 }
 
 // Search and filter users
 export class SearchUserDto {
+  @ApiPropertyOptional({
+    description: 'Search query to filter by username, email, firstName, or lastName',
+    example: 'gabriel',
+  })
   @IsOptional()
   @IsString()
   query?: string; // Search by username, email, firstName, lastName
 
+  @ApiPropertyOptional({
+    description: 'Filter users by role',
+    enum: UserRole,
+    example: UserRole.USER,
+  })
   @IsOptional()
   @IsEnum(UserRole)
   role?: UserRole;
 
+  @ApiPropertyOptional({
+    description: 'Filter by active/inactive status',
+    example: true,
+  })
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Number of records to skip (for pagination)',
+    example: 0,
+    minimum: 0,
+  })
   @IsOptional()
   @IsNumber()
   @Min(0)
   skip?: number;
 
+  @ApiPropertyOptional({
+    description: 'Number of records to take (for pagination, max 100)',
+    example: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @IsNumber()
   @Min(1)
@@ -238,37 +335,122 @@ export class SearchUserDto {
 
 // Paginated user response
 export class PaginatedUsersDto {
+  @ApiProperty({
+    description: 'Array of user profiles',
+    type: [UserProfileDto],
+  })
   data!: UserProfileDto[];
+
+  @ApiProperty({
+    description: 'Total number of matching records',
+    example: 150,
+  })
   total!: number;
+
+  @ApiProperty({
+    description: 'Number of records skipped',
+    example: 0,
+  })
   skip!: number;
+
+  @ApiProperty({
+    description: 'Number of records returned',
+    example: 20,
+  })
   take!: number;
 }
 
 // Avatar upload response
 export class AvatarUploadResponseDto {
+  @ApiProperty({
+    description: 'URL of the uploaded avatar image',
+    example: 'https://cdn.example.com/avatars/user123.png',
+  })
   avatarUrl!: string;
+
+  @ApiProperty({
+    description: 'Success message',
+    example: 'Avatar uploaded successfully',
+  })
   message!: string;
 }
 
 // Role and Permission DTOs
 export class PermissionDto {
+  @ApiProperty({
+    description: 'Unique permission identifier',
+    example: 'clx123abc456',
+  })
   id!: string;
+
+  @ApiProperty({
+    description: 'Permission name',
+    example: 'MANAGE_BOUNTIES',
+  })
   name!: string;
+
+  @ApiPropertyOptional({
+    description: 'Permission description',
+    example: 'Allows creating and managing bounties',
+  })
   description?: string;
 }
 
 export class RoleDto {
+  @ApiProperty({
+    description: 'Unique role identifier',
+    example: 'clx789def012',
+  })
   id!: string;
+
+  @ApiProperty({
+    description: 'Role name',
+    example: 'ADMIN',
+  })
   name!: string;
+
+  @ApiPropertyOptional({
+    description: 'Role description',
+    example: 'Administrator with full access',
+  })
   description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Permissions assigned to this role',
+    type: [PermissionDto],
+  })
   permissions?: PermissionDto[];
 }
 
 // User details (including sensitive info, admin only)
 export class UserDetailsDto extends UserProfileDto {
+  @ApiProperty({
+    description: 'User email address (admin only)',
+    example: 'user@example.com',
+  })
   email!: string;
+
+  @ApiPropertyOptional({
+    description: 'Ethereum wallet address',
+    example: '0x1111111111111111111111111111111111111111',
+  })
   walletAddress?: string;
+
+  @ApiProperty({
+    description: 'Whether the user account is active',
+    example: true,
+  })
   isActive!: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Last login timestamp',
+    example: '2026-04-15T10:30:00.000Z',
+  })
   lastLoginAt?: Date;
+
+  @ApiProperty({
+    description: 'Last update timestamp',
+    example: '2026-04-15T14:20:00.000Z',
+  })
   updatedAt!: Date;
 }


### PR DESCRIPTION
## Description
Implements treasury monitoring service with configurable thresholds per guild (#439).

## Changes
- Added treasury settings to guild settings:
  - `lowBalanceThreshold`: XLM threshold for low balance alerts (default: 100)
  - `lowBalanceAlertEnabled`: Enable/disable alerts per guild (default: true)
  - `treasuryAddress`: Stellar treasury account address (mocked)
- Created `TreasuryMonitorService` with mocked on-chain balance checking
- Added `TreasuryProcessor` for BullMQ queue-based cron job execution
- Scheduled daily treasury check via repeatable job (configurable via `TREASURY_CHECK_CRON` env var, default: `0 9 * * *`)
- Triggers email alerts (via MailerService) and in-app notifications when balance falls below threshold
- Added comprehensive unit tests

## Technical Details
- Uses existing BullMQ infrastructure for job scheduling
- Mock implementation for on-chain balance checking (deterministic hash-based)
- Notifications created in the existing `Notification` model with type `TREASURY_LOW_BALANCE`
- Email alerts sent to all guild admins/owners

## Testing
- All new tests pass: `npm test -- --testPathPatterns="treasury-monitor.service.spec"`
- Guild settings validation tests updated for treasury settings

## Acceptance Criteria
- [x] Daily cron job implemented
- [x] Balance checking with mocked on-chain data
- [x] Configurable `lowBalanceThreshold` per guild
- [x] Email and in-app notifications triggered when balance < threshold