### PR TITLE
[Backend] Automated System Health Status Log (Daily) - #441

### DIFF
--- a/backend/src/health/daily-health-log.service.spec.ts
+++ b/backend/src/health/daily-health-log.service.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DailyHealthLogService } from './daily-health-log.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('DailyHealthLogService', () => {
+  let service: DailyHealthLogService;
+  let prismaService: PrismaService;
+
+  const mockPrismaService = {
+    $queryRaw: jest.fn().mockResolvedValue([{ '?column?': 1 }]),
+    user: { count: jest.fn().mockResolvedValue(100) },
+    guild: { count: jest.fn().mockResolvedValue(25) },
+    bounty: { count: jest.fn().mockResolvedValue(50) },
+    bountyPayout: { count: jest.fn().mockResolvedValue(5) },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DailyHealthLogService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DailyHealthLogService>(DailyHealthLogService);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should build health summary with correct structure', async () => {
+    const summary = await service.buildHealthSummary();
+
+    expect(summary).toHaveProperty('timestamp');
+    expect(summary).toHaveProperty('date');
+    expect(summary).toHaveProperty('database');
+    expect(summary).toHaveProperty('metrics');
+    expect(summary).toHaveProperty('uptime');
+
+    expect(summary.database).toHaveProperty('status', 'connected');
+    expect(summary.database).toHaveProperty('connection', 'healthy');
+
+    expect(summary.metrics).toHaveProperty('totalUsers', 100);
+    expect(summary.metrics).toHaveProperty('totalGuilds', 25);
+    expect(summary.metrics).toHaveProperty('totalBounties', 50);
+    expect(summary.metrics).toHaveProperty('payoutsCreatedToday', 5);
+
+    expect(summary.uptime).toHaveProperty('seconds');
+    expect(summary.uptime).toHaveProperty('formatted');
+  });
+
+  it('should handle database disconnection gracefully', async () => {
+    mockPrismaService.$queryRaw.mockRejectedValueOnce(
+      new Error('Connection refused'),
+    );
+
+    const summary = await service.buildHealthSummary();
+
+    expect(summary.database.status).toBe('disconnected');
+    expect(summary.database.connection).toBe('unhealthy');
+  });
+
+  it('should generate daily health summary without throwing', async () => {
+    const logSpy = jest.spyOn(service['logger'], 'log');
+
+    await expect(
+      service.generateDailyHealthSummary(),
+    ).resolves.not.toThrow();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'Starting daily health summary generation...',
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      'Daily health summary generated successfully.',
+    );
+  });
+
+  it('should log error when summary generation fails', async () => {
+    mockPrismaService.user.count.mockRejectedValueOnce(
+      new Error('DB error'),
+    );
+
+    const errorSpy = jest.spyOn(service['logger'], 'error');
+
+    await service.generateDailyHealthSummary();
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0][0]).toContain(
+      'Failed to generate daily health summary',
+    );
+  });
+});

--- a/backend/src/health/daily-health-log.service.ts
+++ b/backend/src/health/daily-health-log.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service';
+
+export interface DailyHealthSummary {
+  timestamp: string;
+  date: string;
+  database: {
+    status: string;
+    connection: string;
+  };
+  metrics: {
+    totalUsers: number;
+    totalGuilds: number;
+    totalBounties: number;
+    payoutsCreatedToday: number;
+    bountiesCreatedToday: number;
+    usersCreatedToday: number;
+  };
+  uptime: {
+    seconds: number;
+    formatted: string;
+  };
+}
+
+@Injectable()
+export class DailyHealthLogService {
+  private readonly logger = new Logger(DailyHealthLogService.name);
+
+  constructor(private readonly prismaService: PrismaService) {}
+
+  /**
+   * Runs daily at 11:59 PM to log a comprehensive health summary.
+   * Aggregates key metrics and logs them as an Audit event.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_11PM)
+  async generateDailyHealthSummary(): Promise<void> {
+    this.logger.log('Starting daily health summary generation...');
+
+    try {
+      const summary = await this.buildHealthSummary();
+
+      // Log the formatted JSON summary as an Audit event
+      this.logger.log(
+        JSON.stringify(summary, null, 2),
+        'Audit',
+      );
+
+      this.logger.log('Daily health summary generated successfully.');
+    } catch (error) {
+      this.logger.error(
+        `Failed to generate daily health summary: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+    }
+  }
+
+  /**
+   * Builds the health summary by aggregating metrics from the database.
+   */
+  async buildHealthSummary(): Promise<DailyHealthSummary> {
+    const now = new Date();
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const uptime = process.uptime();
+    const hours = Math.floor(uptime / 3600);
+    const minutes = Math.floor((uptime % 3600) / 60);
+    const seconds = Math.floor(uptime % 60);
+
+    // Check database connectivity
+    let dbStatus = 'connected';
+    try {
+      await this.prismaService.$queryRaw`SELECT 1`;
+    } catch {
+      dbStatus = 'disconnected';
+    }
+
+    // Aggregate metrics
+    const [
+      totalUsers,
+      totalGuilds,
+      totalBounties,
+      payoutsCreatedToday,
+      bountiesCreatedToday,
+      usersCreatedToday,
+    ] = await Promise.all([
+      this.prismaService.user.count(),
+      this.prismaService.guild.count(),
+      this.prismaService.bounty.count(),
+      this.prismaService.bountyPayout.count({
+        where: { createdAt: { gte: startOfDay } },
+      }),
+      this.prismaService.bounty.count({
+        where: { createdAt: { gte: startOfDay } },
+      }),
+      this.prismaService.user.count({
+        where: { createdAt: { gte: startOfDay } },
+      }),
+    ]);
+
+    return {
+      timestamp: now.toISOString(),
+      date: now.toISOString().split('T')[0],
+      database: {
+        status: dbStatus,
+        connection: dbStatus === 'connected' ? 'healthy' : 'unhealthy',
+      },
+      metrics: {
+        totalUsers,
+        totalGuilds,
+        totalBounties,
+        payoutsCreatedToday,
+        bountiesCreatedToday,
+        usersCreatedToday,
+      },
+      uptime: {
+        seconds: Math.floor(uptime),
+        formatted: `${hours}h ${minutes}m ${seconds}s`,
+      },
+    };
+  }
+}

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
+import { ScheduleModule } from '@nestjs/schedule';
 import { HealthController } from './health.controller';
 import { PrismaModule } from '../prisma/prisma.module';
+import { DailyHealthLogService } from './daily-health-log.service';
 
 @Module({
-  imports: [TerminusModule, PrismaModule],
+  imports: [TerminusModule, PrismaModule, ScheduleModule.forRoot()],
   controllers: [HealthController],
+  providers: [DailyHealthLogService],
 })
 export class HealthModule {}


### PR DESCRIPTION
## Summary
Closes #441

Implements a daily automated health status log that runs at 11:00 PM every day.

### Changes
- **DailyHealthLogService**: New service with `@Cron(EVERY_DAY_AT_11PM)` decorator
- Aggregates key metrics: total users, total guilds, total bounties, payouts created today, bounties created today, users created today
- Checks database connectivity on each run
- Logs a formatted JSON summary as an **Audit** event via Winston logger
- Health module updated to include `ScheduleModule` for cron support

### Log Output Example
```json
{
  "timestamp": "2026-04-17T23:00:00.000Z",
  "date": "2026-04-17",
  "database": {
    "status": "connected",
    "connection": "healthy"
  },
  "metrics": {
    "totalUsers": 450,
    "totalGuilds": 32,
    "totalBounties": 120,
    "payoutsCreatedToday": 3,
    "bountiesCreatedToday": 5,
    "usersCreatedToday": 8
  },
  "uptime": {
    "seconds": 86400,
    "formatted": "24h 0m 0s"
  }
}
```

### Tests
- Unit tests for `DailyHealthLogService` (5 tests)
- All existing health tests still pass (9 total)