### PR TITLE
feat(user): add onboardingCompleted field to User model

### DIFF
--- a/backend/prisma/migrations/20260417_add_onboarding_completed/migration.sql
+++ b/backend/prisma/migrations/20260417_add_onboarding_completed/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "onboardingCompleted" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -70,6 +70,9 @@ model User {
   walletAddress String?   @unique
   refreshToken  String?
 
+  // Onboarding
+  onboardingCompleted Boolean @default(false)
+
   // Profile fields
   profileBio    String?
   profileUrl    String?

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -116,6 +116,9 @@ export class UserProfileDto {
 
   @ApiProperty({ description: 'User role', enum: UserRole })
   role!: UserRole;
+
+  @ApiProperty({ description: 'Whether user has completed onboarding' })
+  onboardingCompleted!: boolean;
 }
 
 // Update user profile

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -155,6 +155,21 @@ export class UserController {
   }
 
   /**
+   * Mark current user's onboarding as complete
+   */
+  @Post('me/complete-onboarding')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Mark onboarding as complete' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Onboarding marked as complete',
+  })
+  async completeOnboarding(@Request() req: any) {
+    return this.userService.completeOnboarding(req.user.userId);
+  }
+
+  /**
    * Deactivate current user account
    */
   @Delete('me')

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -47,6 +47,7 @@ export class UserService {
         githubHandle: true,
         createdAt: true,
         role: true,
+        onboardingCompleted: true,
       },
     });
 
@@ -93,6 +94,7 @@ export class UserService {
         lastLoginAt: true,
         createdAt: true,
         updatedAt: true,
+        onboardingCompleted: true,
       },
     });
 
@@ -154,6 +156,7 @@ export class UserService {
         createdAt: true,
         updatedAt: true,
         role: true,
+        onboardingCompleted: true,
       },
     });
 
@@ -291,6 +294,7 @@ export class UserService {
           githubHandle: true,
           createdAt: true,
           role: true,
+          onboardingCompleted: true,
         },
         skip,
         take,
@@ -403,6 +407,26 @@ export class UserService {
     });
 
     return { message: 'User account reactivated successfully' };
+  }
+
+  /**
+   * Mark user onboarding as complete
+   */
+  async completeOnboarding(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { onboardingCompleted: true },
+    });
+
+    return { message: 'Onboarding marked as complete' };
   }
 
   // Existing basic CRUD methods (kept for compatibility)


### PR DESCRIPTION
## Summary
Adds `onboardingCompleted` boolean field to the User model to track whether a user has completed the onboarding wizard.

Closes #436

## Changes

### Database
- Added `onboardingCompleted Boolean @default(false)` to the User model in Prisma schema
- Created migration SQL to add the column to the `users` table

### API
- Added `POST /users/me/complete-onboarding` endpoint (authenticated) to mark onboarding as complete
- `onboardingCompleted` field is now included in all user profile responses:
  - `GET /users/me`
  - `GET /users/:userId`
  - `GET /users/details/:userId`
  - `PATCH /users/me`
  - `GET /users/search`

### DTOs
- Added `onboardingCompleted` field to `UserProfileDto`

## Acceptance Criteria
- [x] Update Prisma `User` model with `onboardingCompleted` (default false)
- [x] Implement `POST /users/me/complete-onboarding` which flips this flag to true
- [x] Ensure this field is visible in the profile responses