### PR TITLE
feat: add email notification preference toggle (closes #425)

### DIFF
--- a/backend/prisma/migrations/20260418041400_add_notification_settings/migration.sql
+++ b/backend/prisma/migrations/20260418041400_add_notification_settings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "notificationSettings" JSONB DEFAULT '{"emailOnBounty":true,"emailOnMention":true,"weeklyDigest":true}';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -95,6 +95,9 @@ model User {
   bountyApplications BountyApplication[]
   bountyPayouts      BountyPayout[]
 
+  // Notification preferences
+  notificationSettings Json? @default("{\"emailOnBounty\":true,\"emailOnMention\":true,\"weeklyDigest\":true}")
+
   @@map("users")
 }
 

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -271,4 +271,43 @@ export class UserDetailsDto extends UserProfileDto {
   isActive!: boolean;
   lastLoginAt?: Date;
   updatedAt!: Date;
+  notificationSettings?: NotificationSettingsDto;
+}
+
+// Notification settings
+export class NotificationSettingsDto {
+  @IsBoolean()
+  emailOnBounty!: boolean;
+
+  @IsBoolean()
+  emailOnMention!: boolean;
+
+  @IsBoolean()
+  weeklyDigest!: boolean;
+}
+
+export class UpdateNotificationSettingsDto {
+  @ApiPropertyOptional({
+    description: 'Receive email on bounty updates',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  emailOnBounty?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Receive email on mentions',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  emailOnMention?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Receive weekly digest email',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  weeklyDigest?: boolean;
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -36,6 +36,7 @@ import {
   AssignRoleDto,
   UserRole,
   UserProfileDto,
+  UpdateNotificationSettingsDto,
 } from './dto/user.dto';
 import { validateImageFile } from '../common/utils/file-upload.validator';
 
@@ -94,6 +95,31 @@ export class UserController {
     @Body() updateDto: UpdateUserDto,
   ) {
     return this.userService.updateUserProfile(req.user.userId, updateDto);
+  }
+
+  /**
+   * Update current user notification preferences
+   */
+  @Patch('me/notifications')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update user notification preferences' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Notification preferences updated successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Not authenticated',
+  })
+  async updateNotificationSettings(
+    @Request() req: any,
+    @Body() updateDto: UpdateNotificationSettingsDto,
+  ) {
+    return this.userService.updateNotificationSettings(
+      req.user.userId,
+      updateDto,
+    );
   }
 
   /**

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -14,6 +14,7 @@ import {
   SearchUserDto,
   AssignRoleDto,
   UserRole,
+  UpdateNotificationSettingsDto,
 } from './dto/user.dto';
 import * as bcrypt from 'bcrypt';
 
@@ -158,6 +159,59 @@ export class UserService {
     });
 
     return updated;
+  }
+
+  /**
+   * Update user notification preferences
+   */
+  async updateNotificationSettings(
+    userId: string,
+    updateDto: UpdateNotificationSettingsDto,
+  ) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Get current notification settings or use defaults
+    const defaultSettings = {
+      emailOnBounty: true,
+      emailOnMention: true,
+      weeklyDigest: true,
+    };
+
+    const currentSettings = (user.notificationSettings as any) || defaultSettings;
+
+    // Merge with update
+    const updatedSettings = {
+      ...currentSettings,
+      ...(updateDto.emailOnBounty !== undefined && {
+        emailOnBounty: updateDto.emailOnBounty,
+      }),
+      ...(updateDto.emailOnMention !== undefined && {
+        emailOnMention: updateDto.emailOnMention,
+      }),
+      ...(updateDto.weeklyDigest !== undefined && {
+        weeklyDigest: updateDto.weeklyDigest,
+      }),
+    };
+
+    const updated = await this.prisma.user.update({
+      where: { id: userId },
+      data: { notificationSettings: updatedSettings },
+      select: {
+        id: true,
+        notificationSettings: true,
+      },
+    });
+
+    return {
+      message: 'Notification preferences updated successfully',
+      notificationSettings: updated.notificationSettings,
+    };
   }
 
   /**


### PR DESCRIPTION
## Description
This PR adds email notification preference toggles to user settings, implementing issue #425.

## Changes
- **Prisma Schema**: Added  JSON field to User model with defaults (, , )
- **Migration**: Created SQL migration to add the new column
- **DTOs**: Added  with validation for the three notification flags
- **Controller**: Added  endpoint (authenticated)
- **Service**: Added  method with merge logic to update individual settings

## API Endpoint
```
PATCH /users/me/notifications
Authorization: Bearer <token>
Body: {
  emailOnBounty?: boolean,
  emailOnMention?: boolean,
  weeklyDigest?: boolean
}
```

## Acceptance Criteria Met
- [x] Update Prisma User model to include notificationSettings JSON
- [x] Structure: `{ emailOnBounty: boolean, emailOnMention: boolean, weeklyDigest: boolean }`
- [x] Provide a `PATCH /users/me/notifications` endpoint to update these flags
- [x] Ensure defaults are set to true during registration

Closes #425