### PR TITLE
feat(task3): implement profile completeness XP bonus system

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -76,6 +76,11 @@ model User {
   discordHandle String?
   twitterHandle String?
   githubHandle  String?
+  backgroundCid String?
+
+  // Profile completion tracking
+  hasCompletionBonus Boolean @default(false)
+  xp                 Int     @default(0)
 
   // Relations
   ownedGuilds        Guild[]             @relation("UserOwnerGuilds")

--- a/backend/src/common/utils/profile.util.ts
+++ b/backend/src/common/utils/profile.util.ts
@@ -1,0 +1,43 @@
+export interface UserProfileData {
+  firstName?: string | null;
+  lastName?: string | null;
+  bio?: string | null;
+  location?: string | null;
+  profileBio?: string | null;
+  profileUrl?: string | null;
+  discordHandle?: string | null;
+  twitterHandle?: string | null;
+  githubHandle?: string | null;
+  avatarUrl?: string | null;
+  backgroundCid?: string | null;
+}
+
+/**
+ * Calculate profile completeness percentage based on filled fields
+ * Returns a number between 0 and 100
+ */
+export class ProfileUtil {
+  private static readonly PROFILE_FIELDS: (keyof UserProfileData)[] = [
+    'firstName',
+    'lastName',
+    'bio',
+    'location',
+    'profileBio',
+    'profileUrl',
+    'discordHandle',
+    'twitterHandle',
+    'githubHandle',
+    'avatarUrl',
+    'backgroundCid',
+  ];
+
+  static calculateCompleteness(profile: UserProfileData): number {
+    const totalFields = this.PROFILE_FIELDS.length;
+    const filledFields = this.PROFILE_FIELDS.filter((field) => {
+      const value = profile[field];
+      return value !== null && value !== undefined && value !== '';
+    }).length;
+
+    return Math.round((filledFields / totalFields) * 100);
+  }
+}

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -212,9 +212,9 @@ export class GuildService {
       });
 
       // Calculate TVL for each guild
-      const guildsWithTvl = allGuilds.map((guild) => {
+      const guildsWithTvl = allGuilds.map((guild: any) => {
         const tvl = guild.bounties.reduce(
-          (sum, bounty) => sum + (bounty.rewardAmount || 0),
+          (sum: number, bounty: any) => sum + Number(bounty.rewardAmount || 0),
           0,
         );
         return {
@@ -225,7 +225,7 @@ export class GuildService {
       });
 
       // Sort by TVL descending
-      guildsWithTvl.sort((a, b) => b.tvl - a.tvl);
+      guildsWithTvl.sort((a: any, b: any) => b.tvl - a.tvl);
 
       // Apply pagination
       const paginatedItems = guildsWithTvl.slice(page * size, (page + 1) * size);

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -16,6 +16,7 @@ import {
   UserRole,
 } from './dto/user.dto';
 import * as bcrypt from 'bcrypt';
+import { ProfileUtil } from '../common/utils/profile.util';
 
 @Injectable()
 export class UserService {
@@ -154,10 +155,69 @@ export class UserService {
         createdAt: true,
         updatedAt: true,
         role: true,
+        hasCompletionBonus: true,
+        xp: true,
       },
     });
 
+    // Check profile completeness and award XP bonus if applicable
+    await this.checkAndAwardCompletionBonus(userId, updated);
+
     return updated;
+  }
+
+  /**
+   * Check if user has completed their profile and award XP bonus
+   */
+  private async checkAndAwardCompletionBonus(userId: string, user: any) {
+    // Skip if user already received the bonus
+    if (user.hasCompletionBonus) {
+      return;
+    }
+
+    // Calculate profile completeness
+    const completeness = ProfileUtil.calculateCompleteness({
+      firstName: user.firstName,
+      lastName: user.lastName,
+      bio: user.bio,
+      location: user.location,
+      profileBio: user.profileBio,
+      profileUrl: user.profileUrl,
+      discordHandle: user.discordHandle,
+      twitterHandle: user.twitterHandle,
+      githubHandle: user.githubHandle,
+      avatarUrl: user.avatarUrl,
+      backgroundCid: user.backgroundCid,
+    });
+
+    // Award 50 XP if profile is 100% complete
+    if (completeness === 100) {
+      this.logger.log(`User ${userId} achieved 100% profile completeness. Awarding 50 XP bonus.`);
+
+      await this.prisma.$transaction(async (tx: any) => {
+        // Update user XP and mark bonus as received
+        await tx.user.update({
+          where: { id: userId },
+          data: {
+            xp: { increment: 50 },
+            hasCompletionBonus: true,
+          },
+        });
+
+        // Log the reward in reputation history (notifications table)
+        await tx.notification.create({
+          data: {
+            userId,
+            message: '🎉 Congratulations! You earned 50 XP for completing your profile!',
+            type: 'PROFILE_COMPLETION_BONUS',
+            metadata: {
+              xpAwarded: 50,
+              completeness,
+            },
+          },
+        });
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## 🎯 Profile Completion Bonus (XP Reward System)

### 📌 Description

This PR introduces a reward mechanism that grants users a one-time XP bonus when their profile reaches 100% completeness. The goal is to encourage users to fully complete their profiles by providing a small but meaningful incentive.

---

### 🎯 Objective

Detect when a user’s profile reaches full completion and award a one-time **50 XP bonus**, ensuring the reward is only granted once.

---

### 🛠️ Changes Implemented

* Integrated completeness check into `UserUpdateService`:

  * Calls `ProfileUtil.calculateCompleteness` after each profile update
* Added reward logic:

  * If completeness is **100%** and `hasCompletionBonus` is `false`:

    * Grant **50 XP**
    * Update `hasCompletionBonus` to `true`
* Logged reward event:

  * Records the bonus in reputation history (mocked via log for now)
* Ensured idempotency:

  * Users cannot receive the bonus multiple times

---

### 🧪 Behavior

* Profile updates automatically trigger completeness recalculation
* Bonus is granted immediately upon reaching 100%
* Subsequent updates do not re-trigger the reward

---

### ✅ Acceptance Criteria

* [x] Completeness check runs after every user update
* [x] 50 XP is granted when completeness reaches 100%
* [x] `hasCompletionBonus` prevents duplicate rewards
* [x] Reward event is logged in reputation history

---

### 📎 Notes

* Reputation gain logic is currently mocked (log-based) and can be replaced with a full reputation service later.
* Designed to seamlessly integrate with future gamification features.


closes #404 