### PR TITLE
Add smooth theme transitions with 300ms duration

### DIFF
--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { getMessages } from 'next-intl/server';
 import { NextIntlClientProvider } from 'next-intl';
 import { locales, defaultLocale, type Locale } from '@/i18n';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { ThemeProvider } from "next-themes";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -32,15 +33,21 @@ export default async function RootLayout({
   const messages = await getMessages();
 
   return (
-    <html lang={locale} className="dark">
+    <html lang={locale} suppressHydrationWarning>
       <body className={inter.className}>
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <ErrorBoundary>
-            <div className="min-h-screen flex flex-col bg-stellar-navy text-stellar-white font-sans">
-              {children}
-            </div>
-          </ErrorBoundary>
-        </NextIntlClientProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+        >
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <ErrorBoundary>
+              <div className="min-h-screen flex flex-col bg-white dark:bg-stellar-navy text-gray-900 dark:text-stellar-white font-sans transition-colors duration-300">
+                {children}
+              </div>
+            </ErrorBoundary>
+          </NextIntlClientProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -37,8 +37,8 @@ export default async function RootLayout({
       <body className={inter.className}>
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
-          enableSystem
+          defaultTheme="dark"
+          enableSystem={false}
         >
           <NextIntlClientProvider locale={locale} messages={messages}>
             <ErrorBoundary>

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -21,7 +21,7 @@ export default function HomePage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-slate-950 text-white overflow-x-hidden">
+    <div className="min-h-screen bg-white dark:bg-slate-950 text-gray-900 dark:text-white overflow-x-hidden transition-colors duration-300">
       <Navbar />
       <main>
         <HeroSection />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6,9 +6,10 @@
 
 :root {
   --font-hero: 'Orbitron', sans-serif;
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
+  /* Light mode colors */
+  --foreground-rgb: 15, 23, 42;
+  --background-start-rgb: 248, 250, 252;
+  --background-end-rgb: 241, 245, 249;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -29,6 +29,17 @@ body {
     rgb(var(--background-start-rgb));
 }
 
+/* Smooth theme transition */
+html {
+  transition: background-color 300ms ease-in-out, color 300ms ease-in-out;
+}
+
+html * {
+  transition: background-color 300ms ease-in-out, 
+              border-color 300ms ease-in-out, 
+              color 300ms ease-in-out;
+}
+
 @layer utilities {
   .text-balance {
     text-wrap: balance;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -19,7 +19,6 @@ export default function RootLayout({
                     attribute="class"
                     defaultTheme="system"
                     enableSystem
-                    disableTransitionOnChange
                 >
                     {children}
                 </ThemeProvider>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,11 @@
 import { redirect } from 'next/navigation';
 import { defaultLocale } from '@/i18n';
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+    title: "Stellar Guilds",
+    description: "User Profile & Reputation Dashboard",
+};
 
 // Redirect to the default locale
 export default function RootPage() {

--- a/frontend/src/components/landing-page/layout/Navbar.tsx
+++ b/frontend/src/components/landing-page/layout/Navbar.tsx
@@ -89,17 +89,20 @@ export default function Navbar() {
               </Link>
             </div>
 
-            {/* Mobile Menu Button */}
-            <button
-              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              className="md:hidden p-2 text-gray-700 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-colors"
-            >
-              {isMobileMenuOpen ? (
-                <X className="w-6 h-6" />
-              ) : (
-                <Menu className="w-6 h-6" />
-              )}
-            </button>
+            {/* Mobile Menu Button and Theme Toggle */}
+            <div className="md:hidden flex items-center gap-2">
+              <ThemeToggle />
+              <button
+                onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                className="p-2 text-gray-700 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+              >
+                {isMobileMenuOpen ? (
+                  <X className="w-6 h-6" />
+                ) : (
+                  <Menu className="w-6 h-6" />
+                )}
+              </button>
+            </div>
           </div>
         </div>
       </motion.nav>
@@ -127,8 +130,7 @@ export default function Navbar() {
                   </Link>
                 ))}
                 <div className="pt-4 border-t border-gray-200 dark:border-slate-800 space-y-3">
-                  <div className="w-full flex justify-center gap-3">
-                    <ThemeToggle />
+                  <div className="w-full flex justify-center">
                     <LanguageSelector />
                   </div>
                   <Link href="/onboarding" className="block" onClick={() => setIsMobileMenuOpen(false)}>

--- a/frontend/src/components/landing-page/layout/Navbar.tsx
+++ b/frontend/src/components/landing-page/layout/Navbar.tsx
@@ -37,7 +37,7 @@ export default function Navbar() {
         className={`
           fixed top-0 left-0 right-0 z-50 transition-all duration-300
           ${isScrolled
-            ? "bg-slate-900/80 backdrop-blur-xl border-b border-slate-800/50 shadow-lg shadow-black/20"
+            ? "bg-white/80 dark:bg-slate-900/80 backdrop-blur-xl border-b border-gray-200 dark:border-slate-800/50 shadow-lg"
             : "bg-transparent"
           }
         `}
@@ -52,7 +52,7 @@ export default function Navbar() {
                   <Sparkles className="w-5 h-5 text-white" />
                 </div>
               </div>
-              <span className="text-xl font-bold bg-gradient-to-r from-white to-slate-300 bg-clip-text text-transparent">
+              <span className="text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 dark:from-white dark:to-slate-300 bg-clip-text text-transparent">
                 Stellar Guilds
               </span>
             </div>
@@ -63,7 +63,7 @@ export default function Navbar() {
                 <Link
                   key={link.label}
                   href={link.href}
-                  className="text-slate-300 hover:text-white transition-colors duration-200 text-sm font-medium"
+                  className="text-gray-700 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-colors duration-200 text-sm font-medium"
                 >
                   {link.label}
                 </Link>
@@ -77,7 +77,7 @@ export default function Navbar() {
               <Link href="/onboarding">
                 <Button
                   variant="ghost"
-                  className="text-slate-300 hover:text-white hover:bg-white/5"
+                  className="text-gray-700 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5"
                 >
                   {t('login')}
                 </Button>
@@ -92,7 +92,7 @@ export default function Navbar() {
             {/* Mobile Menu Button */}
             <button
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              className="md:hidden p-2 text-slate-300 hover:text-white transition-colors"
+              className="md:hidden p-2 text-gray-700 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-colors"
             >
               {isMobileMenuOpen ? (
                 <X className="w-6 h-6" />
@@ -114,19 +114,19 @@ export default function Navbar() {
             transition={{ duration: 0.2 }}
             className="fixed inset-x-0 top-20 z-40 md:hidden"
           >
-            <div className="bg-slate-900/95 backdrop-blur-xl border-b border-slate-800 shadow-2xl">
+            <div className="bg-white/95 dark:bg-slate-900/95 backdrop-blur-xl border-b border-gray-200 dark:border-slate-800 shadow-2xl">
               <div className="px-4 py-6 space-y-4">
                 {navLinks.map((link) => (
                   <Link
                     key={link.label}
                     href={link.href}
                     onClick={() => setIsMobileMenuOpen(false)}
-                    className="block w-full text-left px-4 py-3 text-slate-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
+                    className="block w-full text-left px-4 py-3 text-gray-700 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5 rounded-lg transition-colors"
                   >
                     {link.label}
                   </Link>
                 ))}
-                <div className="pt-4 border-t border-slate-800 space-y-3">
+                <div className="pt-4 border-t border-gray-200 dark:border-slate-800 space-y-3">
                   <div className="w-full flex justify-center gap-3">
                     <ThemeToggle />
                     <LanguageSelector />
@@ -134,7 +134,7 @@ export default function Navbar() {
                   <Link href="/onboarding" className="block" onClick={() => setIsMobileMenuOpen(false)}>
                     <Button
                       variant="ghost"
-                      className="w-full justify-center text-slate-300"
+                      className="w-full justify-center text-gray-700 dark:text-slate-300"
                     >
                       Sign In
                     </Button>

--- a/frontend/src/components/landing-page/layout/Navbar.tsx
+++ b/frontend/src/components/landing-page/layout/Navbar.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui";
 import Link from "next/link";
 import LanguageSelector from "@/components/LanguageSelector";
 import { useTranslations } from 'next-intl';
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
 
 export default function Navbar() {
   const t = useTranslations('navigation');
@@ -71,6 +72,7 @@ export default function Navbar() {
 
             {/* Desktop CTA */}
             <div className="hidden md:flex items-center gap-4">
+              <ThemeToggle />
               <LanguageSelector />
               <Link href="/onboarding">
                 <Button
@@ -125,7 +127,8 @@ export default function Navbar() {
                   </Link>
                 ))}
                 <div className="pt-4 border-t border-slate-800 space-y-3">
-                  <div className="w-full flex justify-center">
+                  <div className="w-full flex justify-center gap-3">
+                    <ThemeToggle />
                     <LanguageSelector />
                   </div>
                   <Link href="/onboarding" className="block" onClick={() => setIsMobileMenuOpen(false)}>

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -7,8 +7,8 @@ import { Sun, Moon } from 'lucide-react'
 type Theme = 'light' | 'dark'
 
 const icons: Record<Theme, React.ReactNode> = {
-  light: <Sun size={18} />,
-  dark: <Moon size={18} />,
+  light: <Sun size={18} className="text-yellow-500" />,
+  dark: <Moon size={18} className="text-slate-300" />,
 }
 
 export function ThemeToggle() {
@@ -36,7 +36,7 @@ export function ThemeToggle() {
       aria-label={`Current theme: ${current}. Switch to ${next}`}
       className="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-stellar-lightNavy transition-colors"
     >
-      <div className={`transition-transform duration-300 text-gray-900 dark:text-white ${isRotating ? 'rotate-180' : ''}`}>
+      <div className={`transition-transform duration-300 ${isRotating ? 'rotate-180' : ''}`}>
         {icons[current]}
       </div>
     </button>

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -17,6 +17,7 @@ const icons: Record<Theme, React.ReactNode> = {
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
+  const [isRotating, setIsRotating] = useState(false)
 
   useEffect(() => setMounted(true), [])
 
@@ -26,13 +27,21 @@ export function ThemeToggle() {
   const current = (theme as Theme) ?? 'system'
   const next = THEME_CYCLE[(THEME_CYCLE.indexOf(current) + 1) % THEME_CYCLE.length]
 
+  const handleThemeChange = () => {
+    setIsRotating(true)
+    setTheme(next)
+    setTimeout(() => setIsRotating(false), 300)
+  }
+
   return (
     <button
-      onClick={() => setTheme(next)}
+      onClick={handleThemeChange}
       aria-label={`Current theme: ${current}. Switch to ${next}`}
       className="p-2 rounded-md hover:bg-stellar-lightNavy transition-colors"
     >
-      {icons[current]}
+      <div className={`transition-transform duration-300 ${isRotating ? 'rotate-180' : ''}`}>
+        {icons[current]}
+      </div>
     </button>
   )
 }

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -2,16 +2,13 @@
 
 import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
-import { Sun, Moon, Monitor } from 'lucide-react'
+import { Sun, Moon } from 'lucide-react'
 
-type Theme = 'light' | 'dark' | 'system'
-
-const THEME_CYCLE: Theme[] = ['light', 'dark', 'system']
+type Theme = 'light' | 'dark'
 
 const icons: Record<Theme, React.ReactNode> = {
   light: <Sun size={18} />,
   dark: <Moon size={18} />,
-  system: <Monitor size={18} />,
 }
 
 export function ThemeToggle() {
@@ -24,8 +21,8 @@ export function ThemeToggle() {
   // Render neutral placeholder until hydrated to avoid mismatch
   if (!mounted) return <div className="w-9 h-9" />
 
-  const current = (theme as Theme) ?? 'system'
-  const next = THEME_CYCLE[(THEME_CYCLE.indexOf(current) + 1) % THEME_CYCLE.length]
+  const current = (theme === 'light' ? 'light' : 'dark') as Theme
+  const next: Theme = current === 'light' ? 'dark' : 'light'
 
   const handleThemeChange = () => {
     setIsRotating(true)
@@ -37,7 +34,7 @@ export function ThemeToggle() {
     <button
       onClick={handleThemeChange}
       aria-label={`Current theme: ${current}. Switch to ${next}`}
-      className="p-2 rounded-md hover:bg-stellar-lightNavy transition-colors"
+      className="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-stellar-lightNavy transition-colors"
     >
       <div className={`transition-transform duration-300 ${isRotating ? 'rotate-180' : ''}`}>
         {icons[current]}

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -36,7 +36,7 @@ export function ThemeToggle() {
       aria-label={`Current theme: ${current}. Switch to ${next}`}
       className="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-stellar-lightNavy transition-colors"
     >
-      <div className={`transition-transform duration-300 ${isRotating ? 'rotate-180' : ''}`}>
+      <div className={`transition-transform duration-300 text-gray-900 dark:text-white ${isRotating ? 'rotate-180' : ''}`}>
         {icons[current]}
       </div>
     </button>


### PR DESCRIPTION
Closes #353

---

## Changes
- Added 300ms smooth transitions for theme switching
- Theme toggle now only shows Sun/Moon icons (removed system option)
- Icon rotates 180° when clicked with smooth animation
- Added light mode support throughout the app
- Fixed hardcoded dark mode colors preventing theme changes
- Made sun icon bright yellow for visibility in dark mode
- Positioned theme toggle next to hamburger menu on mobile

## Acceptance Criteria Met
✅ Global CSS transition for background-color and text-color (300ms)
✅ No flickering during theme switch
✅ Toggle button icon animates with rotation
✅ Smooth feel with proper duration
#353 