### PR TITLE
User JWT Token Blacklisting (Redis Store)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,7 +16,7 @@ import { QueueModule } from './queue/queue.module';
 import { ProxylModule } from './proxyl/proxyl.module';
 import { ReputationModule } from './reputation/reputation.module';
 import { ErrorReportingModule } from './common/modules/error-reporting.module';
-import { RedisService } from './common/services/redis.service';
+import { RedisModule } from './common/services/redis.module';
 import { MaintenanceGuard } from './common/guards/maintenance.guard';
 
 @Module({
@@ -32,6 +32,7 @@ import { MaintenanceGuard } from './common/guards/maintenance.guard';
     ]),
     LoggerModule,
     ErrorReportingModule,
+    RedisModule,
     PrismaModule,
     AuthModule,
     UserModule,
@@ -46,7 +47,6 @@ import { MaintenanceGuard } from './common/guards/maintenance.guard';
   controllers: [AppController],
   providers: [
     AppService,
-    RedisService,
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -131,15 +131,16 @@ describe('AuthController', () => {
   describe('logout', () => {
     it('should logout user successfully', async () => {
       const request = { user: { userId: '123' } };
+      const authorization = 'Bearer test-token-123';
 
       jest
         .spyOn(authService, 'logout')
         .mockResolvedValue({ message: 'Logged out successfully' });
 
-      const result = await controller.logout(request);
+      const result = await controller.logout(request, authorization);
 
       expect(result.message).toEqual('Logged out successfully');
-      expect(authService.logout).toHaveBeenCalledWith('123');
+      expect(authService.logout).toHaveBeenCalledWith('123', 'test-token-123');
     });
   });
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   Request,
   HttpCode,
   HttpStatus,
+  Headers,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
@@ -66,8 +67,13 @@ export class AuthController {
   @Post('logout')
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
-  async logout(@Request() req: any) {
-    return this.authService.logout(req.user.userId);
+  async logout(@Request() req: any, @Headers('authorization') authorization: string) {
+    // Extract the token from the Authorization header
+    const token = authorization?.startsWith('Bearer ') 
+      ? authorization.substring(7) 
+      : authorization;
+    
+    return this.authService.logout(req.user.userId, token);
   }
 
   /**

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -7,13 +7,16 @@ import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RoleGuard } from './guards/role.guard';
+import { TokenBlacklistService } from './services/token-blacklist.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { RedisModule } from '../common/services/redis.module';
 
 @Module({
   imports: [
     ConfigModule,
     PrismaModule,
     PassportModule,
+    RedisModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({
@@ -26,7 +29,7 @@ import { PrismaModule } from '../prisma/prisma.module';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, JwtAuthGuard, RoleGuard],
+  providers: [AuthService, JwtStrategy, JwtAuthGuard, RoleGuard, TokenBlacklistService],
   exports: [AuthService, JwtStrategy, JwtAuthGuard, RoleGuard, PassportModule],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -3,6 +3,7 @@ import { AuthService } from './auth.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
+import { TokenBlacklistService } from './services/token-blacklist.service';
 import * as ethers from 'ethers';
 import {
   UnauthorizedException,
@@ -71,6 +72,13 @@ describe('AuthService', () => {
               create: jest.fn(),
               update: jest.fn(),
             },
+          },
+        },
+        {
+          provide: TokenBlacklistService,
+          useValue: {
+            add: jest.fn(),
+            isBlacklisted: jest.fn(),
           },
         },
       ],
@@ -302,11 +310,14 @@ describe('AuthService', () => {
 
   describe('logout', () => {
     it('should successfully logout user', async () => {
+      const mockToken = 'test-access-token';
       jest.spyOn(prisma.user, 'update').mockResolvedValue(mockUser as any);
+      jest.spyOn(service['tokenBlacklistService'], 'add').mockResolvedValue(undefined);
 
-      const result = await service.logout('123');
+      const result = await service.logout('123', mockToken);
 
       expect(result.message).toEqual('Logged out successfully');
+      expect(service['tokenBlacklistService'].add).toHaveBeenCalledWith(mockToken);
       expect(prisma.user.update).toHaveBeenCalledWith({
         where: { id: '123' },
         data: { refreshToken: null },

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -7,6 +7,7 @@ import {
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
+import { TokenBlacklistService } from './services/token-blacklist.service';
 import * as bcrypt from 'bcrypt';
 import { ethers } from 'ethers';
 import {
@@ -25,6 +26,7 @@ export class AuthService {
     private jwtService: JwtService,
     private configService: ConfigService,
     private prisma: PrismaService,
+    private tokenBlacklistService: TokenBlacklistService,
   ) {
     this.jwtSecret =
       this.configService.get<string>('JWT_SECRET') || 'your-secret-key';
@@ -273,9 +275,13 @@ export class AuthService {
   }
 
   /**
-   * Logout user by invalidating refresh token
+   * Logout user by invalidating refresh token and blacklisting access token
    */
-  async logout(userId: string) {
+  async logout(userId: string, accessToken: string) {
+    // Blacklist the current access token
+    await this.tokenBlacklistService.add(accessToken);
+
+    // Clear the refresh token from database
     await this.prisma.user.update({
       where: { id: userId },
       data: { refreshToken: null },

--- a/backend/src/auth/services/token-blacklist.service.spec.ts
+++ b/backend/src/auth/services/token-blacklist.service.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TokenBlacklistService } from './token-blacklist.service';
+import { RedisService } from '../../common/services/redis.service';
+import { JwtService } from '@nestjs/jwt';
+
+describe('TokenBlacklistService', () => {
+  let service: TokenBlacklistService;
+  let redisService: RedisService;
+  let jwtService: JwtService;
+
+  const mockRedisService = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+  };
+
+  const mockJwtService = {
+    decode: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TokenBlacklistService,
+        {
+          provide: RedisService,
+          useValue: mockRedisService,
+        },
+        {
+          provide: JwtService,
+          useValue: mockJwtService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TokenBlacklistService>(TokenBlacklistService);
+    redisService = module.get<RedisService>(RedisService);
+    jwtService = module.get<JwtService>(JwtService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('add', () => {
+    it('should add token to blacklist with correct TTL', async () => {
+      const token = 'test.jwt.token';
+      const futureTime = Math.floor(Date.now() / 1000) + 900; // 15 minutes from now
+
+      mockJwtService.decode.mockReturnValue({ exp: futureTime });
+
+      await service.add(token);
+
+      expect(jwtService.decode).toHaveBeenCalledWith(token);
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining('blacklist:token:'),
+        'blacklisted',
+        expect.any(Number),
+      );
+    });
+
+    it('should not blacklist expired tokens', async () => {
+      const token = 'test.jwt.token';
+      const pastTime = Math.floor(Date.now() / 1000) - 100; // 100 seconds ago
+
+      mockJwtService.decode.mockReturnValue({ exp: pastTime });
+
+      await service.add(token);
+
+      expect(redisService.set).not.toHaveBeenCalled();
+    });
+
+    it('should handle tokens without expiration', async () => {
+      const token = 'test.jwt.token';
+
+      mockJwtService.decode.mockReturnValue({ sub: '123' });
+
+      await service.add(token);
+
+      expect(redisService.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isBlacklisted', () => {
+    it('should return true if token is blacklisted', async () => {
+      const token = 'test.jwt.token';
+
+      mockRedisService.get.mockResolvedValue('blacklisted');
+
+      const result = await service.isBlacklisted(token);
+
+      expect(result).toBe(true);
+      expect(redisService.get).toHaveBeenCalledWith(
+        expect.stringContaining('blacklist:token:'),
+      );
+    });
+
+    it('should return false if token is not blacklisted', async () => {
+      const token = 'test.jwt.token';
+
+      mockRedisService.get.mockResolvedValue(null);
+
+      const result = await service.isBlacklisted(token);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if Redis is unavailable', async () => {
+      const token = 'test.jwt.token';
+
+      mockRedisService.get.mockRejectedValue(new Error('Redis error'));
+
+      const result = await service.isBlacklisted(token);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/backend/src/auth/services/token-blacklist.service.ts
+++ b/backend/src/auth/services/token-blacklist.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { RedisService } from '../../common/services/redis.service';
+
+@Injectable()
+export class TokenBlacklistService {
+  private readonly logger = new Logger(TokenBlacklistService.name);
+  private readonly BLACKLIST_PREFIX = 'blacklist:token:';
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  /**
+   * Add a token to the blacklist with TTL matching token's remaining life
+   * @param token - The JWT access token to blacklist
+   */
+  async add(token: string): Promise<void> {
+    try {
+      // Decode the token to get expiration time
+      const decoded = this.jwtService.decode(token) as { exp?: number } | null;
+
+      if (!decoded || !decoded.exp) {
+        this.logger.warn('Cannot blacklist token: unable to decode or missing expiration');
+        return;
+      }
+
+      const currentTime = Math.floor(Date.now() / 1000);
+      const ttl = decoded.exp - currentTime;
+
+      // Only blacklist if token hasn't already expired
+      if (ttl > 0) {
+        const key = this.getBlacklistKey(token);
+        await this.redisService.set(key, 'blacklisted', ttl);
+        this.logger.debug(`Token blacklisted with TTL: ${ttl} seconds`);
+      } else {
+        this.logger.debug('Token already expired, skipping blacklist');
+      }
+    } catch (error) {
+      this.logger.error('Failed to blacklist token', error);
+    }
+  }
+
+  /**
+   * Check if a token is blacklisted
+   * @param token - The JWT access token to check
+   * @returns true if the token is blacklisted, false otherwise
+   */
+  async isBlacklisted(token: string): Promise<boolean> {
+    try {
+      const key = this.getBlacklistKey(token);
+      const result = await this.redisService.get(key);
+      return result === 'blacklisted';
+    } catch (error) {
+      this.logger.error('Failed to check token blacklist status', error);
+      // If Redis is unavailable, assume token is not blacklisted
+      // This prevents blocking all requests during Redis outages
+      return false;
+    }
+  }
+
+  /**
+   * Generate a Redis key for the token
+   * Uses a hash of the token to keep keys short and consistent
+   * @param token - The JWT token
+   * @returns Redis key string
+   */
+  private getBlacklistKey(token: string): string {
+    // Create a simple hash from the token to use as Redis key
+    // This keeps keys short while maintaining uniqueness
+    let hash = 0;
+    for (let i = 0; i < token.length; i++) {
+      const char = token.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+    return `${this.BLACKLIST_PREFIX}${Math.abs(hash).toString(36)}`;
+  }
+}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+import { TokenBlacklistService } from '../services/token-blacklist.service';
 
 interface JwtPayload {
   sub: string;
@@ -14,15 +15,27 @@ interface JwtPayload {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private configService: ConfigService) {
+  constructor(
+    private configService: ConfigService,
+    private tokenBlacklistService: TokenBlacklistService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
       secretOrKey: configService.get<string>('JWT_SECRET') || 'your-secret-key',
+      passReqToCallback: true,
     });
   }
 
-  async validate(payload: JwtPayload) {
+  async validate(req: Request, payload: JwtPayload) {
+    // Extract the token from the request
+    const token = ExtractJwt.fromAuthHeaderAsBearerToken()(req);
+
+    // Check if token is blacklisted
+    if (token && await this.tokenBlacklistService.isBlacklisted(token)) {
+      throw new UnauthorizedException('Token has been revoked');
+    }
+
     return {
       userId: payload.sub,
       email: payload.email,

--- a/backend/src/common/services/redis.module.ts
+++ b/backend/src/common/services/redis.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { RedisService } from './redis.service';
+
+@Global()
+@Module({
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class RedisModule {}


### PR DESCRIPTION
close #373
## Implemented a Redis-based JWT token blacklisting system for the Stellar-Guilds backend.
 Here's what was implemented:

## 1. TokenBlacklistService ([token-blacklist.service.ts]src/auth/services/token-blacklist.service.ts))

- add(token): Adds a token to the Redis blacklist with TTL matching the token's remaining lifetime
- isBlacklisted(token): Checks if a token is in the blacklist
- Uses token hashing to create concise Redis keys
- Handles edge cases (expired tokens, Redis failures gracefully)

## 2. Updated JwtStrategy ([jwt.strategy.ts]/src/auth/strategies/jwt.strategy.ts))
- Now checks every incoming token against the blacklist during validation
- Returns 401 Unauthorized with message "Token has been revoked" if token is blacklisted
- Uses passReqToCallback: true to access the raw token from the request

## 3. Updated AuthService ([auth.service.ts]/src/auth/auth.service.ts))
- logout() method now accepts the access token and blacklists it before clearing the refresh token
- Ensures both access and refresh tokens are invalidated on logout

## 4. Updated AuthController ([auth.controller.ts]/src/auth/auth.controller.ts))
- Extracts the token from the Authorization header
- Passes it to the logout service method

5. Created RedisModule ([redis.module.ts](file:///C:/Users/r-zakariyau/drips/Stellar-Guilds/backend/src/common/services/redis.module.ts))
Global module that provides RedisService across the application
Properly integrated into the app module
6. Updated AuthModule ([auth.module.ts]src/auth/auth.module.ts))
- Imports RedisModule
- Provides TokenBlacklistService

## 7. Updated Tests
- [auth.service.spec.ts]/src/auth/auth.service.spec.ts): Updated logout test with token blacklisting
- [auth.controller.spec.ts]/src/auth/auth.controller.spec.ts): Updated logout test with authorization header
- [token-blacklist.service.spec.ts]/src/auth/services/token-blacklist.service.spec.ts): Comprehensive unit tests for the blacklist service

🔑 Key Features
TTL-based Blacklisting: Tokens are stored in Redis with a TTL matching their remaining expiration time, so they automatically clean up
Stateless JWT Logout: Solves the classic problem of invalidating stateless JWT tokens
Graceful Degradation: If Redis is unavailable, the system assumes tokens are valid (prevents blocking all requests)
Security: Blacklisted tokens return 401 immediately, even if they haven't expired
Efficient Storage: Uses token hashing to keep Redis keys short and consistent

🔄 Flow
User calls POST /auth/logout with their JWT token
Controller extracts token from Authorization: Bearer <token> header
Service blacklists the token in Redis with TTL = token's remaining life
Service clears the refresh token from the database
On subsequent requests, JwtStrategy checks the blacklist
If token is blacklisted, request is rejected with 401

📝 Acceptance Criteria Met
✅ Created TokenBlacklistService with add(token) and isBlacklisted(token)
✅ Set TTL on Redis keys matching token's remaining life
✅ Updated JwtStrategy to check blacklist on every request
✅ Rejects requests with 401 Unauthorized if token is blacklisted
✅ Handles the stateless JWT logout problem definitively