### PR TITLE
Feat/profile

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "@nestjs/throttler": "^6.5.0",
         "@prisma/client": "5.18.0",
         "@types/multer": "^2.1.0",
+        "axios": "^1.15.2",
         "bcrypt": "^6.0.0",
         "bullmq": "^5.71.1",
         "class-transformer": "^0.5.1",
@@ -4413,8 +4414,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "30.2.0",
@@ -5208,7 +5219,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5507,7 +5517,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -5793,7 +5802,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6431,6 +6439,26 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -6480,7 +6508,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -6497,7 +6524,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6507,7 +6533,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -6828,7 +6853,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9344,6 +9368,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4413,18 +4413,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
     },
     "node_modules/babel-jest": {
       "version": "30.2.0",
@@ -5218,6 +5208,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5516,6 +5507,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -5801,6 +5793,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6438,26 +6431,6 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -6507,6 +6480,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -6523,6 +6497,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6532,6 +6507,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -6852,6 +6828,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9367,15 +9344,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,6 +42,7 @@
     "@nestjs/throttler": "^6.5.0",
     "@prisma/client": "5.18.0",
     "@types/multer": "^2.1.0",
+    "axios": "^1.15.2",
     "bcrypt": "^6.0.0",
     "bullmq": "^5.71.1",
     "class-transformer": "^0.5.1",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -139,7 +139,7 @@ model Guild {
 model GuildMembership {
   id                  String           @id @default(cuid())
   createdAt           DateTime         @default(now())
-  joinedAt            DateTime?
+  joinedAt            DateTime         @default(now())
   status              MembershipStatus @default(APPROVED)
   invitationToken     String?
   invitedById         String?

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -145,6 +145,7 @@ model GuildMembership {
   invitedById         String?
   invitationExpiresAt DateTime?
   role                GuildRole        @default(MEMBER)
+  bio                 String?
   userId              String
   guildId             String
 

--- a/backend/prisma/update-joined-at.ts
+++ b/backend/prisma/update-joined-at.ts
@@ -1,0 +1,25 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function updateJoinedAt() {
+  console.log('Starting joinedAt update...');
+
+  const result = await prisma.guildMembership.updateMany({
+    where: {
+      joinedAt: null,
+    },
+    data: {
+      joinedAt: new Date(), // This will be set to createdAt in a proper migration, but for script, use current time or query each
+    },
+  });
+
+  console.log(`Updated ${result.count} records`);
+
+  // Actually, to set to createdAt, we need to do it one by one or use raw SQL
+  // For simplicity, since it's one-off, and new records get now(), existing null get now() as approximation
+
+  await prisma.$disconnect();
+}
+
+updateJoinedAt().catch(console.error);

--- a/backend/prisma/update-joined-at.ts
+++ b/backend/prisma/update-joined-at.ts
@@ -5,26 +5,12 @@ const prisma = new PrismaClient();
 async function updateJoinedAt() {
   console.log('Starting joinedAt update...');
 
-  // Get all memberships with null joinedAt
-  const memberships = await prisma.guildMembership.findMany({
-    where: {
-      joinedAt: null,
-    },
-    select: {
-      id: true,
-      createdAt: true,
-    },
-  });
-
-  console.log(`Found ${memberships.length} records to update`);
-
-  // Update each one
-  for (const membership of memberships) {
-    await prisma.guildMembership.update({
-      where: { id: membership.id },
-      data: { joinedAt: membership.createdAt },
-    });
-  }
+  // Use raw SQL to update records where joinedAt is null, set to createdAt
+  await prisma.$executeRaw`
+    UPDATE "guild_memberships"
+    SET "joinedAt" = "createdAt"
+    WHERE "joinedAt" IS NULL
+  `;
 
   console.log('Update completed');
 

--- a/backend/prisma/update-joined-at.ts
+++ b/backend/prisma/update-joined-at.ts
@@ -5,19 +5,28 @@ const prisma = new PrismaClient();
 async function updateJoinedAt() {
   console.log('Starting joinedAt update...');
 
-  const result = await prisma.guildMembership.updateMany({
+  // Get all memberships with null joinedAt
+  const memberships = await prisma.guildMembership.findMany({
     where: {
       joinedAt: null,
     },
-    data: {
-      joinedAt: new Date(), // This will be set to createdAt in a proper migration, but for script, use current time or query each
+    select: {
+      id: true,
+      createdAt: true,
     },
   });
 
-  console.log(`Updated ${result.count} records`);
+  console.log(`Found ${memberships.length} records to update`);
 
-  // Actually, to set to createdAt, we need to do it one by one or use raw SQL
-  // For simplicity, since it's one-off, and new records get now(), existing null get now() as approximation
+  // Update each one
+  for (const membership of memberships) {
+    await prisma.guildMembership.update({
+      where: { id: membership.id },
+      data: { joinedAt: membership.createdAt },
+    });
+  }
+
+  console.log('Update completed');
 
   await prisma.$disconnect();
 }

--- a/backend/src/common/utils/__tests__/social.util.spec.ts
+++ b/backend/src/common/utils/__tests__/social.util.spec.ts
@@ -1,0 +1,43 @@
+import { SocialUtil, PlatformEnum } from '../social.util';
+
+describe('SocialUtil', () => {
+  describe('identifyPlatform', () => {
+    it('should identify GitHub URLs', () => {
+      expect(SocialUtil.identifyPlatform('https://github.com/user')).toBe(PlatformEnum.GITHUB);
+      expect(SocialUtil.identifyPlatform('http://github.com/user')).toBe(PlatformEnum.GITHUB);
+      expect(SocialUtil.identifyPlatform('github.com/user')).toBe(PlatformEnum.GITHUB);
+      expect(SocialUtil.identifyPlatform('www.github.com/user')).toBe(PlatformEnum.GITHUB);
+      expect(SocialUtil.identifyPlatform('https://www.github.com/user')).toBe(PlatformEnum.GITHUB);
+      expect(SocialUtil.identifyPlatform('api.github.com')).toBe(PlatformEnum.GITHUB);
+    });
+
+    it('should identify Twitter URLs', () => {
+      expect(SocialUtil.identifyPlatform('https://twitter.com/user')).toBe(PlatformEnum.TWITTER);
+      expect(SocialUtil.identifyPlatform('twitter.com/user')).toBe(PlatformEnum.TWITTER);
+      expect(SocialUtil.identifyPlatform('www.twitter.com/user')).toBe(PlatformEnum.TWITTER);
+    });
+
+    it('should identify X URLs', () => {
+      expect(SocialUtil.identifyPlatform('https://x.com/user')).toBe(PlatformEnum.X);
+      expect(SocialUtil.identifyPlatform('x.com/user')).toBe(PlatformEnum.X);
+      expect(SocialUtil.identifyPlatform('www.x.com/user')).toBe(PlatformEnum.X);
+    });
+
+    it('should identify Discord URLs', () => {
+      expect(SocialUtil.identifyPlatform('https://discord.gg/invite')).toBe(PlatformEnum.DISCORD);
+      expect(SocialUtil.identifyPlatform('discord.gg/invite')).toBe(PlatformEnum.DISCORD);
+    });
+
+    it('should return UNKNOWN for unrecognized URLs', () => {
+      expect(SocialUtil.identifyPlatform('https://example.com')).toBe(PlatformEnum.UNKNOWN);
+      expect(SocialUtil.identifyPlatform('linkedin.com/user')).toBe(PlatformEnum.UNKNOWN);
+      expect(SocialUtil.identifyPlatform('invalid-url')).toBe(PlatformEnum.UNKNOWN);
+      expect(SocialUtil.identifyPlatform('')).toBe(PlatformEnum.UNKNOWN);
+    });
+
+    it('should handle invalid URLs gracefully', () => {
+      expect(SocialUtil.identifyPlatform('not-a-url')).toBe(PlatformEnum.UNKNOWN);
+      expect(SocialUtil.identifyPlatform('http://')).toBe(PlatformEnum.UNKNOWN);
+    });
+  });
+});

--- a/backend/src/common/utils/social.util.ts
+++ b/backend/src/common/utils/social.util.ts
@@ -1,0 +1,34 @@
+export enum PlatformEnum {
+  GITHUB = 'github',
+  TWITTER = 'twitter',
+  X = 'x',
+  DISCORD = 'discord',
+  UNKNOWN = 'unknown',
+}
+
+export class SocialUtil {
+  static identifyPlatform(url: string): PlatformEnum {
+    try {
+      let fullUrl = url;
+      if (!url.startsWith('http://') && !url.startsWith('https://')) {
+        fullUrl = 'https://' + url;
+      }
+      const hostname = new URL(fullUrl).hostname.toLowerCase();
+      const domain = hostname.split('.').slice(-2).join('.');
+      switch (domain) {
+        case 'github.com':
+          return PlatformEnum.GITHUB;
+        case 'twitter.com':
+          return PlatformEnum.TWITTER;
+        case 'x.com':
+          return PlatformEnum.X;
+        case 'discord.gg':
+          return PlatformEnum.DISCORD;
+        default:
+          return PlatformEnum.UNKNOWN;
+      }
+    } catch {
+      return PlatformEnum.UNKNOWN;
+    }
+  }
+}

--- a/backend/src/guild/dto/update-guild-membership.dto.ts
+++ b/backend/src/guild/dto/update-guild-membership.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateGuildMembershipDto {
+  @ApiPropertyOptional({
+    description: 'Guild-specific bio for the member',
+    example: 'Lead Rust Developer for Stellar Guilds',
+    maxLength: 1000,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  bio?: string;
+}

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -26,6 +26,7 @@ import { InviteMemberDto } from './dto/invite-member.dto';
 import { ApproveInviteDto } from './dto/approve-invite.dto';
 import { SearchGuildDto } from './dto/search-guild.dto';
 import { GuildDetailsDto } from './dto/guild-details.dto';
+import { UpdateGuildMembershipDto } from './dto/update-guild-membership.dto';
 import { validateImageFile } from '../common/utils/file-upload.validator';
 import {
   ApiTags,

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -25,7 +25,7 @@ import { UpdateGuildDto } from './dto/update-guild.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
 import { ApproveInviteDto } from './dto/approve-invite.dto';
 import { SearchGuildDto } from './dto/search-guild.dto';
-import { UpdateGuildMembershipDto } from './dto/update-guild-membership.dto';
+import { GuildDetailsDto } from './dto/guild-details.dto';
 import { validateImageFile } from '../common/utils/file-upload.validator';
 import {
   ApiTags,

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -25,7 +25,7 @@ import { UpdateGuildDto } from './dto/update-guild.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
 import { ApproveInviteDto } from './dto/approve-invite.dto';
 import { SearchGuildDto } from './dto/search-guild.dto';
-import { GuildDetailsDto } from './dto/guild-details.dto';
+import { UpdateGuildMembershipDto } from './dto/update-guild-membership.dto';
 import { validateImageFile } from '../common/utils/file-upload.validator';
 import {
   ApiTags,
@@ -336,5 +336,18 @@ export class GuildController {
       req.user.userId,
       file.buffer,
     );
+  }
+
+  /**
+   * Update the current user's guild membership bio
+   */
+  @UseGuards(JwtAuthGuard)
+  @Patch(':guildId/members/me')
+  async updateMyMembership(
+    @Param('guildId') guildId: string,
+    @Body() dto: UpdateGuildMembershipDto,
+    @Request() req: any,
+  ) {
+    return this.guildService.updateMembership(req.user.userId, guildId, dto);
   }
 }

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -15,9 +15,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { UseInterceptors, UploadedFile } from '@nestjs/common';
 import { GuildBulkInviteService } from './guild-bulk-invite.service';
-import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { GuildRoleGuard } from './guards/guild-role.guard';
 import { GuildRoles } from './decorators/guild-roles.decorator';
@@ -327,7 +325,7 @@ export class GuildController {
   async bulkInvite(
     @Param('id') id: string,
     @UploadedFile() file: Express.Multer.File,
-    @Req() req: any,
+    @Request() req: any,
   ) {
     if (!file) {
       return { error: 'No file uploaded' };

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -12,7 +12,7 @@ import { MailerService } from '../mailer/mailer.service';
 import { StorageService } from '../storage/storage.service';
 import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
-import { UpdateGuildMembershipDto } from './dto/update-guild-membership.dto';
+import { InviteMemberDto } from './dto/invite-member.dto';
 import { randomUUID } from 'crypto';
 
 @Injectable()

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -13,6 +13,7 @@ import { StorageService } from '../storage/storage.service';
 import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
+import { UpdateGuildMembershipDto } from './dto/update-guild-membership.dto';
 import { randomUUID } from 'crypto';
 
 @Injectable()

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -12,7 +12,7 @@ import { MailerService } from '../mailer/mailer.service';
 import { StorageService } from '../storage/storage.service';
 import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
-import { InviteMemberDto } from './dto/invite-member.dto';
+import { UpdateGuildMembershipDto } from './dto/update-guild-membership.dto';
 import { randomUUID } from 'crypto';
 
 @Injectable()
@@ -597,5 +597,17 @@ export class GuildService {
     });
 
     return updated;
+  }
+
+  async updateMembership(userId: string, guildId: string, dto: UpdateGuildMembershipDto) {
+    const membership = await this.prisma.guildMembership.findUnique({
+      where: { userId_guildId: { userId, guildId } },
+    });
+    if (!membership) throw new NotFoundException('Membership not found');
+
+    return this.prisma.guildMembership.update({
+      where: { id: membership.id },
+      data: dto,
+    });
   }
 }

--- a/backend/src/treasury/payout-report.service.ts
+++ b/backend/src/treasury/payout-report.service.ts
@@ -48,8 +48,8 @@ export class PayoutReportService {
 
     // Calculate summary stats
     const totalPayouts = payouts.length;
-    const totalAmount = payouts.reduce((sum, payout) => sum + Number(payout.amount), 0);
-    const completedPayouts = payouts.filter(p => p.status === 'SENT').length;
+    const totalAmount = payouts.reduce((sum: number, payout: any) => sum + Number(payout.amount), 0);
+    const completedPayouts = payouts.filter((p: any) => p.status === 'SENT').length;
 
     // Generate HTML
     const html = `

--- a/backend/src/treasury/payout-report.service.ts
+++ b/backend/src/treasury/payout-report.service.ts
@@ -101,7 +101,7 @@ export class PayoutReportService {
             </tr>
         </thead>
         <tbody>
-            ${payouts.map(payout => `
+            ${payouts.map((payout: any) => `
                 <tr>
                     <td>${payout.createdAt.toLocaleDateString()}</td>
                     <td>${payout.toUser.firstName} ${payout.toUser.lastName} (${payout.toUser.username})</td>

--- a/backend/src/treasury/payout-report.service.ts
+++ b/backend/src/treasury/payout-report.service.ts
@@ -1,0 +1,121 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class PayoutReportService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async generateHtml(guildId: string): Promise<string> {
+    // Fetch guild info
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+      select: {
+        name: true,
+        avatarUrl: true,
+        createdAt: true,
+      },
+    });
+
+    if (!guild) {
+      throw new Error('Guild not found');
+    }
+
+    // Fetch payouts with related data
+    const payouts = await this.prisma.bountyPayout.findMany({
+      where: {
+        bounty: {
+          guildId,
+        },
+      },
+      include: {
+        bounty: {
+          select: {
+            title: true,
+          },
+        },
+        toUser: {
+          select: {
+            username: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    // Calculate summary stats
+    const totalPayouts = payouts.length;
+    const totalAmount = payouts.reduce((sum, payout) => sum + Number(payout.amount), 0);
+    const completedPayouts = payouts.filter(p => p.status === 'SENT').length;
+
+    // Generate HTML
+    const html = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Payout Report - ${guild.name}</title>
+    <style>
+        @media print {
+            body { font-family: Arial, sans-serif; margin: 20px; }
+            .header { text-align: center; margin-bottom: 30px; }
+            .logo { max-width: 100px; max-height: 100px; }
+            .summary { margin: 20px 0; padding: 10px; background-color: #f5f5f5; }
+            table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+            th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+            th { background-color: #f2f2f2; font-weight: bold; }
+            .total { font-weight: bold; }
+            .status-sent { color: green; }
+            .status-pending { color: orange; }
+            .status-failed { color: red; }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        ${guild.avatarUrl ? `<img src="${guild.avatarUrl}" alt="${guild.name} Logo" class="logo"><br>` : ''}
+        <h1>${guild.name} - Payout Report</h1>
+        <p>Generated on ${new Date().toLocaleDateString()}</p>
+    </div>
+
+    <div class="summary">
+        <h2>Summary</h2>
+        <p><strong>Total Payouts:</strong> ${totalPayouts}</p>
+        <p><strong>Completed Payouts:</strong> ${completedPayouts}</p>
+        <p><strong>Total Amount:</strong> ${totalAmount.toFixed(2)} STELLAR</p>
+    </div>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>User</th>
+                <th>Bounty</th>
+                <th>Amount</th>
+                <th>Token</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            ${payouts.map(payout => `
+                <tr>
+                    <td>${payout.createdAt.toLocaleDateString()}</td>
+                    <td>${payout.toUser.firstName} ${payout.toUser.lastName} (${payout.toUser.username})</td>
+                    <td>${payout.bounty.title}</td>
+                    <td>${Number(payout.amount).toFixed(2)}</td>
+                    <td>${payout.token}</td>
+                    <td class="status-${payout.status.toLowerCase()}">${payout.status}</td>
+                </tr>
+            `).join('')}
+        </tbody>
+    </table>
+</body>
+</html>`;
+
+    return html;
+  }
+}

--- a/backend/src/treasury/treasury.module.ts
+++ b/backend/src/treasury/treasury.module.ts
@@ -3,6 +3,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { QUEUE_NAMES } from '../queue/queue.constants';
 import { TreasuryService } from './treasury.service';
 import { TreasuryEventProcessor } from './treasury-event.processor';
+import { PayoutReportService } from './payout-report.service';
 
 @Module({
   imports: [
@@ -10,7 +11,7 @@ import { TreasuryEventProcessor } from './treasury-event.processor';
       name: QUEUE_NAMES.ON_CHAIN_EVENTS,
     }),
   ],
-  providers: [TreasuryService, TreasuryEventProcessor],
-  exports: [TreasuryService],
+  providers: [TreasuryService, TreasuryEventProcessor, PayoutReportService],
+  exports: [TreasuryService, PayoutReportService],
 })
 export class TreasuryModule {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Stellar-Guildss",
+  "name": "Stellar-Guilds",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## ✅ Error Fixed

**Issue:** TypeScript error in `prisma/update-joined-at.ts` - `joinedAt: null` was not assignable because the schema now defines `joinedAt` as required with a default value.

**Solution:** Updated the script to use raw SQL instead of Prisma's typed query methods, allowing it to update existing records where `joinedAt` is `NULL` by setting it to the `createdAt` value.

The script now uses:
```sql
UPDATE "guild_memberships"
SET "joinedAt" = "createdAt"
WHERE "joinedAt" IS NULL
```

This approach works around the type constraint since raw SQL doesn't enforce the Prisma-generated types, allowing the one-off data migration to run successfully on existing data before the schema change was applied.

The build completes without errors, and all implementations are ready for deployment.

Made changes.

Closes #427 
Closes #435 
Closes #422 
Closes #372 