### PR TITLE
feat: api versioning, guild applications, reputation pagination, api keys

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -103,6 +103,7 @@ model User {
   privacySettings    PrivacySettings?
   bountyApplications BountyApplication[]
   bountyPayouts      BountyPayout[]
+  apiKeys            ApiKey[]
 
   @@index([role])
   @@index([isActive])
@@ -358,4 +359,18 @@ model TreasuryTransaction {
   @@index([guildId])
   @@index([txHash])
   @@map("treasury_transactions")
+}
+
+model ApiKey {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  userId    String
+  keyHash   String   @unique
+  label     String?
+  revokedAt DateTime?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("api_keys")
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { LoggerModule } from './logger/logger.module';
 import { QueueModule } from './queue/queue.module';
 import { ProxylModule } from './proxyl/proxyl.module';
 import { ReputationModule } from './reputation/reputation.module';
+import { VersionModule } from './version/version.module';
 import { ErrorReportingModule } from './common/modules/error-reporting.module';
 import { RedisModule } from './common/services/redis.module';
 import { MaintenanceGuard } from './common/guards/maintenance.guard';
@@ -43,6 +44,7 @@ import { MaintenanceGuard } from './common/guards/maintenance.guard';
     QueueModule,
     ProxylModule,
     ReputationModule,
+    VersionModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -3,6 +3,8 @@ import {
   Post,
   Body,
   Get,
+  Delete,
+  Param,
   UseGuards,
   Request,
   HttpCode,
@@ -10,6 +12,7 @@ import {
   Headers,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
+import { ApiKeyService } from './services/api-key.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import {
   RegisterDto,
@@ -21,7 +24,10 @@ import {
 
 @Controller('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private apiKeyService: ApiKeyService,
+  ) {}
 
   /**
    * Register a new user
@@ -84,5 +90,21 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   async getCurrentUser(@Request() req: any) {
     return this.authService.getCurrentUser(req.user.userId);
+  }
+
+  /** Generate a new API key for the authenticated user */
+  @Post('api-keys')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.CREATED)
+  async createApiKey(@Request() req: any, @Body('label') label?: string) {
+    return this.apiKeyService.create(req.user.userId, label);
+  }
+
+  /** Revoke an API key owned by the authenticated user */
+  @Delete('api-keys/:id')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async revokeApiKey(@Param('id') id: string, @Request() req: any) {
+    return this.apiKeyService.revoke(id, req.user.userId);
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,6 +8,8 @@ import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RoleGuard } from './guards/role.guard';
 import { TokenBlacklistService } from './services/token-blacklist.service';
+import { ApiKeyService } from './services/api-key.service';
+import { ApiKeyGuard } from './guards/api-key.guard';
 import { PrismaModule } from '../prisma/prisma.module';
 import { RedisModule } from '../common/services/redis.module';
 
@@ -29,7 +31,7 @@ import { RedisModule } from '../common/services/redis.module';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, JwtAuthGuard, RoleGuard, TokenBlacklistService],
-  exports: [AuthService, JwtStrategy, JwtAuthGuard, RoleGuard, PassportModule],
+  providers: [AuthService, JwtStrategy, JwtAuthGuard, RoleGuard, TokenBlacklistService, ApiKeyService, ApiKeyGuard],
+  exports: [AuthService, JwtStrategy, JwtAuthGuard, RoleGuard, PassportModule, ApiKeyService, ApiKeyGuard],
 })
 export class AuthModule {}

--- a/backend/src/auth/guards/api-key.guard.ts
+++ b/backend/src/auth/guards/api-key.guard.ts
@@ -1,0 +1,19 @@
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ApiKeyService } from '../services/api-key.service';
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  constructor(private readonly apiKeyService: ApiKeyService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const rawKey = request.headers['x-api-key'];
+    if (!rawKey) throw new UnauthorizedException('Missing X-API-KEY header');
+
+    const apiKey = await this.apiKeyService.validateKey(rawKey);
+    if (!apiKey) throw new UnauthorizedException('Invalid or revoked API key');
+
+    request.apiKeyUserId = apiKey.userId;
+    return true;
+  }
+}

--- a/backend/src/auth/services/api-key.service.ts
+++ b/backend/src/auth/services/api-key.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ApiKeyService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(userId: string, label?: string) {
+    const rawKey = randomBytes(16).toString('hex'); // 32 hex chars
+    const keyHash = createHash('sha256').update(rawKey).digest('hex');
+
+    await this.prisma.apiKey.create({ data: { userId, keyHash, label } });
+
+    // Return raw key ONCE — never stored
+    return { key: rawKey, label };
+  }
+
+  async revoke(id: string, userId: string) {
+    const apiKey = await this.prisma.apiKey.findUnique({ where: { id } });
+    if (!apiKey) throw new NotFoundException('API key not found');
+    if (apiKey.userId !== userId) throw new ForbiddenException();
+
+    return this.prisma.apiKey.update({
+      where: { id },
+      data: { revokedAt: new Date() },
+    });
+  }
+
+  async validateKey(rawKey: string) {
+    const keyHash = createHash('sha256').update(rawKey).digest('hex');
+    const apiKey = await this.prisma.apiKey.findUnique({ where: { keyHash } });
+    if (!apiKey || apiKey.revokedAt) return null;
+    return apiKey;
+  }
+}

--- a/backend/src/guild/application.service.ts
+++ b/backend/src/guild/application.service.ts
@@ -1,0 +1,52 @@
+import {
+  Injectable,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
+import { MembershipStatus, GuildRole } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ApplicationService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async apply(userId: string, guildId: string) {
+    const existing = await this.prisma.guildMembership.findFirst({
+      where: { userId, guildId, status: MembershipStatus.PENDING },
+    });
+    if (existing) throw new ConflictException('Pending application already exists');
+
+    return this.prisma.guildMembership.create({
+      data: { userId, guildId, status: MembershipStatus.PENDING, role: GuildRole.MEMBER },
+    });
+  }
+
+  async updateStatus(
+    applicationId: string,
+    status: MembershipStatus,
+    adminId: string,
+  ) {
+    // Mocked admin check
+    const admin = await this.prisma.user.findUnique({ where: { id: adminId } });
+    if (!admin || admin.role !== 'ADMIN') throw new ForbiddenException('Admins only');
+
+    const application = await this.prisma.guildMembership.findUnique({
+      where: { id: applicationId },
+    });
+    if (!application) throw new NotFoundException('Application not found');
+    if (application.status !== MembershipStatus.PENDING)
+      throw new BadRequestException('Only PENDING applications can be updated');
+    if (status === MembershipStatus.PENDING)
+      throw new BadRequestException('Cannot transition back to PENDING');
+
+    return this.prisma.guildMembership.update({
+      where: { id: applicationId },
+      data: {
+        status,
+        ...(status === MembershipStatus.APPROVED ? { joinedAt: new Date() } : {}),
+      },
+    });
+  }
+}

--- a/backend/src/guild/guild.module.ts
+++ b/backend/src/guild/guild.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { GuildController } from './guild.controller';
 import { GuildService } from './guild.service';
 import { GuildBulkInviteService } from './guild-bulk-invite.service';
+import { ApplicationService } from './application.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { MailerModule } from '../mailer/mailer.module';
 import { StorageModule } from '../storage/storage.module';
@@ -9,8 +10,8 @@ import { StorageModule } from '../storage/storage.module';
 @Module({
   imports: [PrismaModule, MailerModule, StorageModule],
   controllers: [GuildController],
-  providers: [GuildService, GuildBulkInviteService],
-  exports: [GuildService],
+  providers: [GuildService, GuildBulkInviteService, ApplicationService],
+  exports: [GuildService, ApplicationService],
 })
 export class GuildModule {}
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import { NestFactory, HttpAdapterHost } from '@nestjs/core';
+import { VersioningType } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
@@ -16,6 +17,9 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger: new WinstonLogger('Bootstrap'),
   });
+
+  app.setGlobalPrefix('api');
+  app.enableVersioning({ type: VersioningType.URI });
 
   const logger = new WinstonLogger('Main');
   const httpAdapterHost = app.get(HttpAdapterHost);

--- a/backend/src/reputation/reputation.controller.ts
+++ b/backend/src/reputation/reputation.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
 import { ReputationService } from './reputation.service';
 import { CreateReputationDto } from './dto/create-reputation.dto';
 import { UpdateReputationDto } from './dto/update-reputation.dto';

--- a/backend/src/reputation/reputation.module.ts
+++ b/backend/src/reputation/reputation.module.ts
@@ -5,5 +5,6 @@ import { ReputationController } from './reputation.controller';
 @Module({
   controllers: [ReputationController],
   providers: [ReputationService],
+  exports: [ReputationService],
 })
 export class ReputationModule {}

--- a/backend/src/reputation/reputation.service.ts
+++ b/backend/src/reputation/reputation.service.ts
@@ -2,6 +2,26 @@ import { Injectable } from '@nestjs/common';
 import { CreateReputationDto } from './dto/create-reputation.dto';
 import { UpdateReputationDto } from './dto/update-reputation.dto';
 
+// Mock reputation event shape
+interface ReputationEvent {
+  id: string;
+  userId: string;
+  points: number;
+  reason: string;
+  createdAt: Date;
+}
+
+// Generate 100 mock events for a given userId
+function mockEvents(userId: string): ReputationEvent[] {
+  return Array.from({ length: 100 }, (_, i) => ({
+    id: `evt-${i + 1}`,
+    userId,
+    points: Math.floor(Math.random() * 50) + 1,
+    reason: `Task #${i + 1} completed`,
+    createdAt: new Date(Date.now() - i * 3_600_000), // descending by 1h
+  }));
+}
+
 @Injectable()
 export class ReputationService {
   create(createReputationDto: CreateReputationDto) {
@@ -22,5 +42,32 @@ export class ReputationService {
 
   remove(id: number) {
     return `This action removes a #${id} reputation`;
+  }
+
+  /**
+   * Cursor-based pagination over mock reputation events.
+   * Events are ordered descending by createdAt (index on userId + createdAt).
+   */
+  getReputationHistory(
+    userId: string,
+    limit = 20,
+    cursor?: string,
+  ): { data: ReputationEvent[]; nextCursor: string | null; hasMore: boolean } {
+    const all = mockEvents(userId); // already desc by createdAt
+
+    let startIndex = 0;
+    if (cursor) {
+      const idx = all.findIndex((e) => e.id === cursor);
+      startIndex = idx === -1 ? 0 : idx + 1;
+    }
+
+    const slice = all.slice(startIndex, startIndex + limit);
+    const hasMore = startIndex + limit < all.length;
+
+    return {
+      data: slice,
+      nextCursor: hasMore ? slice[slice.length - 1].id : null,
+      hasMore,
+    };
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -43,10 +43,14 @@ import {
   NotificationPreferencesDto,
 } from './dto/notification-preferences.dto';
 import { validateImageFile } from '../common/utils/file-upload.validator';
+import { ReputationService } from '../reputation/reputation.service';
 
 @Controller('users')
 export class UserController {
-  constructor(private userService: UserService) {}
+  constructor(
+    private userService: UserService,
+    private reputationService: ReputationService,
+  ) {}
 
   /**
    * Get current authenticated user profile
@@ -290,5 +294,21 @@ export class UserController {
   @HttpCode(HttpStatus.OK)
   async reactivateUser(@Param('userId') userId: string) {
     return this.userService.reactivateUser(userId);
+  }
+
+  /**
+   * Get paginated reputation history for a user (cursor-based)
+   */
+  @Get(':id/reputation')
+  getReputation(
+    @Param('id') id: string,
+    @Query('limit') limit?: string,
+    @Query('cursor') cursor?: string,
+  ) {
+    return this.reputationService.getReputationHistory(
+      id,
+      limit ? parseInt(limit, 10) : 20,
+      cursor,
+    );
   }
 }

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -4,9 +4,10 @@ import { UserController } from './user.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
 import { StorageModule } from '../storage/storage.module';
+import { ReputationModule } from '../reputation/reputation.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, StorageModule],
+  imports: [PrismaModule, AuthModule, StorageModule, ReputationModule],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/backend/src/version/version.controller.ts
+++ b/backend/src/version/version.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Get, Version } from '@nestjs/common';
+
+@Controller('version')
+export class VersionController {
+  @Get()
+  @Version('1')
+  getV1() {
+    return { version: 'v1', status: 'ok' };
+  }
+}

--- a/backend/src/version/version.module.ts
+++ b/backend/src/version/version.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { VersionController } from './version.controller';
+
+@Module({ controllers: [VersionController] })
+export class VersionModule {}


### PR DESCRIPTION
Closes #394, closes #395, closes #396, closes #401

## Changes

- **#395** – `setGlobalPrefix('api')` + `VersioningType.URI` in `main.ts`; `VersionController` with `@Version('1')` mock endpoint
- **#394** – `ApplicationService.updateStatus()` state machine: only PENDING→APPROVED/REJECTED allowed; mocked admin check; auto-sets `joinedAt` on approval; blocks duplicate pending applications
- **#396** – Cursor-based pagination on `GET /users/:id/reputation` (`limit` + `cursor` query params, returns `nextCursor` + `hasMore`); mock repo of 100 events ordered desc by `createdAt`
- **#401** – `ApiKey` Prisma model (SHA-256 hash stored, never raw key); `POST /auth/api-keys` returns raw key once; `ApiKeyGuard` validates `X-API-KEY` header; `DELETE /auth/api-keys/:id` revokes own keys