### PR TITLE
Guild banner image support

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -121,6 +121,7 @@ model Guild {
   description String?
   avatarUrl   String?
   bannerUrl   String?
+  bannerCid   String?
   ownerId     String
   settings    Json?
   memberCount Int       @default(1)

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -340,6 +340,47 @@ export class GuildController {
   }
 
   /**
+   * Update guild banner CID
+   * Accepts JSON body with bannerCid string
+   */
+  @UseGuards(JwtAuthGuard, GuildRoleGuard)
+  @GuildRoles('ADMIN', 'OWNER')
+  @Patch(':id/banner')
+  @ApiOperation({ summary: 'Update guild banner CID' })
+  @ApiParam({ name: 'id', description: 'Guild ID (UUID)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        bannerCid: {
+          type: 'string',
+          description: 'Banner CID string for IPFS storage',
+        },
+      },
+      required: ['bannerCid'],
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Banner CID updated successfully',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid banner CID',
+  })
+  async updateBannerCid(
+    @Param('id') id: string,
+    @Body() body: { bannerCid: string },
+    @Request() req: any,
+  ) {
+    return this.guildService.updateGuildBannerCid(
+      id,
+      body.bannerCid,
+      req.user.userId,
+    );
+  }
+
+  /**
    * Update the current user's guild membership bio
    */
   @UseGuards(JwtAuthGuard)

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -600,6 +600,32 @@ export class GuildService {
     return updated;
   }
 
+  /**
+   * Update guild banner CID
+   */
+  async updateGuildBannerCid(guildId: string, bannerCid: string, userId: string) {
+    await this.ensureManagePermission(guildId, userId);
+
+    const guild = await this.prisma.guild.findUnique({
+      where: { id: guildId },
+    });
+
+    if (!guild) {
+      throw new NotFoundException('Guild not found');
+    }
+
+    if (!bannerCid || typeof bannerCid !== 'string') {
+      throw new BadRequestException('Invalid banner CID');
+    }
+
+    const updated = await this.prisma.guild.update({
+      where: { id: guildId },
+      data: { bannerCid },
+    });
+
+    return updated;
+  }
+
   async updateMembership(userId: string, guildId: string, dto: UpdateGuildMembershipDto) {
     const membership = await this.prisma.guildMembership.findUnique({
       where: { userId_guildId: { userId, guildId } },


### PR DESCRIPTION
closes #443 

 Summary
This PR adds a `bannerCid` field to the Guild schema, enabling large banner/hero images for cinematic dashboard presentation. The implementation includes database schema changes and a new PATCH endpoint restricted to admin users.
    Independence Note
Pure schema and basic update logic - This is a standalone change with no external dependencies, completing the standard branding fields for guild identities alongside existing logos.

