### PR TITLE
automated guild invitation

### DIFF
--- a/backend/src/guild/guild-invitation-cleanup.service.ts
+++ b/backend/src/guild/guild-invitation-cleanup.service.ts
@@ -1,0 +1,133 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class GuildInvitationCleanupService {
+  private readonly logger = new Logger(GuildInvitationCleanupService.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async cleanupExpiredInvitations(): Promise<void> {
+    this.logger.log('Starting expired invitation cleanup job...');
+    
+    try {
+      const now = new Date();
+      
+      // Find expired pending invitations
+      const expiredInvitations = await this.prisma.guildMembership.findMany({
+        where: {
+          status: 'PENDING',
+          invitationExpiresAt: {
+            lt: now,
+          },
+          invitationToken: {
+            not: null,
+          },
+        },
+        select: {
+          id: true,
+          userId: true,
+          guildId: true,
+          invitationExpiresAt: true,
+          user: {
+            select: {
+              id: true,
+              username: true,
+              email: true,
+            },
+          },
+          guild: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      });
+
+      if (expiredInvitations.length === 0) {
+        this.logger.log('No expired invitations found to clean up.');
+        return;
+      }
+
+      // Delete expired invitations
+      const deleteResult = await this.prisma.guildMembership.deleteMany({
+        where: {
+          id: {
+            in: expiredInvitations.map((inv: any) => inv.id),
+          },
+        },
+      });
+
+      this.logger.log(
+        `Successfully cleaned up ${deleteResult.count} expired guild invitations.`,
+      );
+
+      // Log details of cleaned invitations for audit purposes
+      if (this.logger.context.includes('debug')) {
+        expiredInvitations.forEach((inv: any) => {
+          this.logger.debug(
+            `Deleted expired invitation for user ${inv.user?.username || inv.userId} to guild ${inv.guild?.name || inv.guildId} (expired: ${inv.invitationExpiresAt})`,
+          );
+        });
+      }
+
+    } catch (error) {
+      this.logger.error(
+        'Failed to cleanup expired invitations',
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
+  }
+
+  /**
+   * Manual cleanup method for testing or immediate cleanup
+   */
+  async manualCleanup(): Promise<{ deletedCount: number }> {
+    this.logger.log('Running manual expired invitation cleanup...');
+    
+    try {
+      const now = new Date();
+      
+      const expiredInvitations = await this.prisma.guildMembership.findMany({
+        where: {
+          status: 'PENDING',
+          invitationExpiresAt: {
+            lt: now,
+          },
+          invitationToken: {
+            not: null,
+          },
+        },
+        select: { id: true },
+      });
+
+      if (expiredInvitations.length === 0) {
+        return { deletedCount: 0 };
+      }
+
+      const deleteResult = await this.prisma.guildMembership.deleteMany({
+        where: {
+          id: {
+            in: expiredInvitations.map((inv: any) => inv.id),
+          },
+        },
+      });
+
+      this.logger.log(
+        `Manual cleanup completed: ${deleteResult.count} expired invitations removed.`,
+      );
+
+      return { deletedCount: deleteResult.count };
+      
+    } catch (error) {
+      this.logger.error(
+        'Manual cleanup failed',
+        error instanceof Error ? error.stack : String(error),
+      );
+      throw error;
+    }
+  }
+}

--- a/backend/src/guild/guild.module.ts
+++ b/backend/src/guild/guild.module.ts
@@ -1,16 +1,18 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { GuildController } from './guild.controller';
 import { GuildService } from './guild.service';
 import { GuildBulkInviteService } from './guild-bulk-invite.service';
+import { GuildInvitationCleanupService } from './guild-invitation-cleanup.service';
 import { ApplicationService } from './application.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { MailerModule } from '../mailer/mailer.module';
 import { StorageModule } from '../storage/storage.module';
 
 @Module({
-  imports: [PrismaModule, MailerModule, StorageModule],
+  imports: [ScheduleModule.forRoot(), PrismaModule, MailerModule, StorageModule],
   controllers: [GuildController],
-  providers: [GuildService, GuildBulkInviteService, ApplicationService],
+  providers: [GuildService, GuildBulkInviteService, ApplicationService, GuildInvitationCleanupService],
   exports: [GuildService, ApplicationService],
 })
 export class GuildModule {}

--- a/backend/test-invitation-cleanup.ts
+++ b/backend/test-invitation-cleanup.ts
@@ -1,0 +1,34 @@
+// Simple test script to verify the invitation cleanup functionality
+// This can be run manually to test the cleanup service
+
+import { PrismaService } from './src/prisma/prisma.service';
+import { GuildInvitationCleanupService } from './src/guild/guild-invitation-cleanup.service';
+
+async function testCleanup() {
+  console.log('Testing invitation cleanup functionality...');
+  
+  // Initialize services (this would normally be done by NestJS DI)
+  const prisma = new PrismaService();
+  const cleanupService = new GuildInvitationCleanupService(prisma);
+  
+  try {
+    // Test manual cleanup
+    const result = await cleanupService.manualCleanup();
+    console.log(`Cleanup test completed. Deleted ${result.deletedCount} expired invitations.`);
+    
+    // You can also call the scheduled method directly for testing
+    // await cleanupService.cleanupExpiredInvitations();
+    
+  } catch (error) {
+    console.error('Test failed:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Run the test if this file is executed directly
+if (require.main === module) {
+  testCleanup();
+}
+
+export { testCleanup };


### PR DESCRIPTION
closes #424 


This PR introduces a scheduled cleanup task that removes expired guild invitation records, reducing database bloat and minimizing unauthorized entry surface area.

