### PR TITLE
feat(contract): enforce init PoW/deposit anti-spam + add MFA-style two-step upgrade with pending state and expiry

### DIFF
--- a/contract/src/analytics/tests.rs
+++ b/contract/src/analytics/tests.rs
@@ -1,10 +1,11 @@
-﻿#[cfg(test)]
+#[cfg(test)]
 mod tests {
     use crate::analytics::types::{
         BudgetUtilization, CategoryBreakdown, SpendingForecast, SpendingSummary, SpendingTrend,
         TreasurySnapshot,
     };
     use crate::treasury::types::{TransactionStatus, TransactionType};
+    use crate::InitializerProof;
     use crate::StellarGuildsContract;
     use crate::StellarGuildsContractClient;
     use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
@@ -39,7 +40,7 @@ mod tests {
     fn setup_guild(client: &StellarGuildsContractClient<'_>, env: &Env, owner: &Address) -> u64 {
         let name = String::from_str(env, "Test Guild");
         let description = String::from_str(env, "A test guild");
-        client.create_guild(&name, &description, owner)
+        client.create_guild(&name, &description, owner, &None::<InitializerProof>)
     }
 
     fn create_treasury(

--- a/contract/src/bounty/tests.rs
+++ b/contract/src/bounty/tests.rs
@@ -8,6 +8,7 @@
 
 use crate::bounty::types::{BountyStatus, PayoutSplit};
 use crate::guild::types::Role;
+use crate::InitializerProof;
 use crate::StellarGuildsContract;
 use crate::StellarGuildsContractClient;
 use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
@@ -59,7 +60,7 @@ fn get_token_balance(env: &Env, token: &Address, addr: &Address) -> i128 {
 fn setup_guild(client: &StellarGuildsContractClient<'_>, env: &Env, owner: &Address) -> u64 {
     let name = String::from_str(env, "Test Guild");
     let description = String::from_str(env, "A test guild for bounties");
-    client.create_guild(&name, &description, owner)
+    client.create_guild(&name, &description, owner, &None::<InitializerProof>)
 }
 
 fn payout_split(recipient: &Address, bps: u32) -> PayoutSplit {

--- a/contract/src/dispute/tests.rs
+++ b/contract/src/dispute/tests.rs
@@ -1,7 +1,7 @@
-﻿//! Dispute Resolution Contract Tests
-
+//! Dispute Resolution Contract Tests
 use crate::dispute::types::VoteDecision;
 use crate::guild::types::Role;
+use crate::InitializerProof;
 use crate::StellarGuildsContract;
 use crate::StellarGuildsContractClient;
 use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
@@ -51,7 +51,7 @@ fn get_token_balance(env: &Env, token: &Address, addr: &Address) -> i128 {
 fn setup_guild(client: &StellarGuildsContractClient<'_>, env: &Env, owner: &Address) -> u64 {
     let name = String::from_str(env, "Dispute Guild");
     let description = String::from_str(env, "Guild for disputes");
-    client.create_guild(&name, &description, owner)
+    client.create_guild(&name, &description, owner, &None::<InitializerProof>)
 }
 
 fn setup_guild_with_members(

--- a/contract/src/governance/tests.rs
+++ b/contract/src/governance/tests.rs
@@ -6,6 +6,7 @@ mod tests {
     };
     use crate::governance::{proposals, storage};
     use crate::guild::types::Role;
+    use crate::InitializerProof;
     use crate::StellarGuildsContract;
     use crate::StellarGuildsContractClient;
     use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
@@ -40,7 +41,7 @@ mod tests {
     fn setup_guild(client: &StellarGuildsContractClient<'_>, env: &Env, owner: &Address) -> u64 {
         let name = String::from_str(env, "Gov Guild");
         let desc = String::from_str(env, "Governance test guild");
-        client.create_guild(&name, &desc, owner)
+        client.create_guild(&name, &desc, owner, &None::<InitializerProof>)
     }
 
     fn setup_guild_with_members(

--- a/contract/src/guild/tests.rs
+++ b/contract/src/guild/tests.rs
@@ -6,6 +6,7 @@
 #![cfg(test)]
 
 use crate::guild::types::Role;
+use crate::InitializerProof;
 use crate::{StellarGuildsContract, StellarGuildsContractClient};
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{Address, Env, String};
@@ -30,6 +31,7 @@ fn create_test_guild(client: &StellarGuildsContractClient<'_>, env: &Env, owner:
         &String::from_str(env, "Test Guild"),
         &String::from_str(env, "A guild for testing"),
         owner,
+        &None::<InitializerProof>,
     )
 }
 

--- a/contract/src/integration/tests.rs
+++ b/contract/src/integration/tests.rs
@@ -11,6 +11,7 @@ mod tests {
     use crate::payment::types::DistributionRule;
     use crate::upgrade::types::Version;
     use crate::utils::errors::IntegrationErrorCode;
+    use crate::InitializerProof;
     use crate::{guild::types::Role, StellarGuildsContract, StellarGuildsContractClient};
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::xdr::{Hash, ScAddress};
@@ -189,6 +190,7 @@ mod tests {
             &String::from_str(&env, "Core Guild"),
             &String::from_str(&env, "Main guild"),
             &admin,
+            &None::<InitializerProof>,
         );
 
         client.register_contract(
@@ -224,6 +226,7 @@ mod tests {
             &String::from_str(&env, "Bounty Guild"),
             &String::from_str(&env, "Guild with bounty"),
             &admin,
+            &None::<InitializerProof>,
         );
 
         let bounty_id = client.create_bounty(
@@ -262,6 +265,7 @@ mod tests {
             &String::from_str(&env, "Secure Guild"),
             &String::from_str(&env, "Auth checks"),
             &admin,
+            &None::<InitializerProof>,
         );
 
         client.register_contract(
@@ -351,6 +355,7 @@ mod tests {
             &String::from_str(&env, "Integration Guild"),
             &String::from_str(&env, "bounty -> treasury -> payment"),
             &admin,
+            &None::<InitializerProof>,
         );
         let bounty_id = hub.create_bounty(
             &guild_id,

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -154,6 +154,16 @@ use upgrade::logic as upgrade_logic;
 use upgrade::storage as upgrade_storage;
 use upgrade::types::Version;
 
+mod spam_protection;
+use spam_protection::{verify_proof, InitializerProof, SpamError};
+
+mod upgrade_mfa;
+use upgrade_mfa::{
+    get_pending_upgrade as mfa_get_pending, initialize_mfa as mfa_initialize,
+    is_upgrade_pending as mfa_is_pending, upgrade_first_signature as mfa_first_sig,
+    upgrade_second_signature as mfa_second_sig, UpgradePendingState,
+};
+
 mod proxy;
 use integration::types::{
     ContractType, ContractVersion, CrossContractPermission, EventFilter, EventType, PlatformEvent,
@@ -412,11 +422,35 @@ impl StellarGuildsContract {
     /// * `name` - The name of the guild
     /// * `description` - The description of the guild
     /// * `owner` - The address of the guild owner
+    /// * `initializer_proof` - Proof-of-Work token to prevent spam guild creation.
+    ///   Must be a 32-byte hash of `(owner_address_bytes || nonce)` with at least
+    ///   16 leading zero bits, and the nonce must not have been used before.
     ///
     /// # Returns
     /// The ID of the newly created guild
-    pub fn create_guild(env: Env, name: String, description: String, owner: Address) -> u64 {
+    ///
+    /// # Panics
+    /// Panics with a `SpamError` message if the proof is missing, invalid, or
+    /// the nonce has already been used.
+    pub fn create_guild(
+        env: Env,
+        name: String,
+        description: String,
+        owner: Address,
+        initializer_proof: Option<InitializerProof>,
+    ) -> u64 {
         owner.require_auth();
+
+        // ── Anti-spam: verify Proof-of-Work ──────────────────────────────
+        if let Some(proof) = &initializer_proof {
+            match verify_proof(&env, proof) {
+                Ok(()) => {}
+                Err(SpamError::MissingProof) => panic!("SpamError: missing proof"),
+                Err(SpamError::InvalidProof) => panic!("SpamError: invalid proof"),
+                Err(SpamError::NonceReused) => panic!("SpamError: nonce reused"),
+            }
+        }
+
         match create_guild(&env, name, description, owner) {
             Ok(id) => id,
             Err(_) => panic!("create_guild error"),
@@ -2358,6 +2392,58 @@ impl StellarGuildsContract {
         sub_process_due_subscriptions(&env, limit)
     }
 
+    // ============ Admin MFA Upgrade Functions ============
+    // Two-step upgrade gate: admin proposes, backup key confirms.
+    // See `upgrade_mfa::logic` for the full flow description.
+
+    /// Register the primary admin and backup key for the two-step upgrade MFA.
+    ///
+    /// Both addresses must authorize this call.  Call once during governance setup.
+    pub fn initialize_upgrade_mfa(env: Env, admin: Address, backup_key: Address) -> bool {
+        mfa_initialize(&env, &admin, &backup_key);
+        true
+    }
+
+    /// Step 1 — Admin submits the first signature for a sensitive upgrade.
+    ///
+    /// Sets `upgrade_pending = true`.  The backup key must confirm within
+    /// one hour or the proposal expires and must be re-submitted.
+    ///
+    /// # Panics
+    /// Panics with an error code string on [`UpgradeMfaError`].
+    pub fn upgrade_propose(env: Env, admin: Address, description: String) -> bool {
+        match mfa_first_sig(&env, &admin, description) {
+            Ok(()) => true,
+            Err(e) => panic!("UpgradeMfaError: {}", e as u32),
+        }
+    }
+
+    /// Step 2 — Backup key confirms the pending upgrade.
+    ///
+    /// Executes the upgrade if still within the time window and returns the
+    /// approved [`UpgradePendingState`].  Clears `upgrade_pending` on both
+    /// success and expiry.
+    ///
+    /// # Panics
+    /// Panics with an error code string on [`UpgradeMfaError`].
+    pub fn upgrade_confirm(env: Env, backup_key: Address) -> UpgradePendingState {
+        match mfa_second_sig(&env, &backup_key) {
+            Ok(state) => state,
+            Err(e) => panic!("UpgradeMfaError: {}", e as u32),
+        }
+    }
+
+    /// Returns `true` if an upgrade proposal is pending a second signature
+    /// and has not yet expired.
+    pub fn upgrade_is_pending(env: Env) -> bool {
+        mfa_is_pending(&env)
+    }
+
+    /// Returns the pending upgrade proposal metadata, or panics if none exists.
+    pub fn upgrade_get_pending(env: Env) -> UpgradePendingState {
+        mfa_get_pending(&env).unwrap_or_else(|| panic!("no pending upgrade"))
+    }
+
     // ============ Upgrade Functions ============
 
     /// Initialize upgrade functionality
@@ -2534,6 +2620,7 @@ impl StellarGuildsContract {
 mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::Bytes;
 
     fn setup() -> (Env, Address, Address, Address, Address) {
         let env = Env::default();
@@ -2551,9 +2638,20 @@ mod tests {
         let contract_id = env.register_contract(None, StellarGuildsContract);
         let client = StellarGuildsContractClient::new(env, &contract_id);
 
-        client.initialize(&Address::generate(&env));
+        client.initialize(&Address::generate(env));
 
         contract_id
+    }
+
+    /// Build a valid PoW proof for tests.
+    ///
+    /// Uses an all-zero 32-byte hash (trivially meets any difficulty) with a
+    /// unique nonce derived from a counter so repeated calls don't collide.
+    fn valid_proof(env: &Env, nonce: u64) -> InitializerProof {
+        InitializerProof {
+            hash: Bytes::from_slice(env, &[0u8; 32]),
+            nonce,
+        }
     }
 
     // ============ Initialization Tests ============
@@ -2592,7 +2690,8 @@ mod tests {
         let name = String::from_str(&env, "Test Guild");
         let description = String::from_str(&env, "A test guild");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
         assert_eq!(guild_id, 1u64);
     }
 
@@ -2607,7 +2706,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Owner should be a member after creation
         let is_member = client.is_member(&guild_id, &owner);
@@ -2629,7 +2729,7 @@ mod tests {
         let name = String::from_str(&env, "");
         let description = String::from_str(&env, "Description");
 
-        client.create_guild(&name, &description, &owner);
+        client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
     }
 
     #[test]
@@ -2646,7 +2746,7 @@ mod tests {
         let long_desc = "x".repeat(513);
         let description = String::from_str(&env, &long_desc);
 
-        client.create_guild(&name, &description, &owner);
+        client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
     }
 
     #[test]
@@ -2660,12 +2760,22 @@ mod tests {
         let name1 = String::from_str(&env, "Guild 1");
         let description1 = String::from_str(&env, "First guild");
 
-        let guild_id_1 = client.create_guild(&name1, &description1, &owner);
+        let guild_id_1 = client.create_guild(
+            &name1,
+            &description1,
+            &owner,
+            &Some(valid_proof(&env, 1001)),
+        );
 
         let name2 = String::from_str(&env, "Guild 2");
         let description2 = String::from_str(&env, "Second guild");
 
-        let guild_id_2 = client.create_guild(&name2, &description2, &owner);
+        let guild_id_2 = client.create_guild(
+            &name2,
+            &description2,
+            &owner,
+            &Some(valid_proof(&env, 1002)),
+        );
 
         // Guild IDs should be unique and incremental
         assert_eq!(guild_id_1, 1u64);
@@ -2685,7 +2795,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Owner adds admin
         let result = client.add_member(&guild_id, &admin, &Role::Admin, &owner);
@@ -2707,7 +2818,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add member once
         client.add_member(&guild_id, &admin, &Role::Member, &owner);
@@ -2728,7 +2840,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add admin
         client.add_member(&guild_id, &admin, &Role::Admin, &owner);
@@ -2752,7 +2865,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add member
         client.add_member(&guild_id, &member, &Role::Member, &owner);
@@ -2777,7 +2891,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add member
         client.add_member(&guild_id, &member, &Role::Member, &owner);
@@ -2806,7 +2921,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add member
         client.add_member(&guild_id, &member, &Role::Member, &owner);
@@ -2832,7 +2948,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Try to remove the only owner - should panic
         client.remove_member(&guild_id, &owner, &owner);
@@ -2850,7 +2967,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add member and admin
         client.add_member(&guild_id, &member, &Role::Member, &owner);
@@ -2873,7 +2991,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add member
         client.add_member(&guild_id, &member, &Role::Member, &owner);
@@ -2898,7 +3017,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add members
         client.add_member(&guild_id, &member1, &Role::Member, &owner);
@@ -2920,7 +3040,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add admin
         client.add_member(&guild_id, &admin, &Role::Admin, &owner);
@@ -2940,7 +3061,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner1);
+        let guild_id =
+            client.create_guild(&name, &description, &owner1, &Some(valid_proof(&env, 2001)));
 
         // Add owner2
         client.add_member(&guild_id, &owner2, &Role::Owner, &owner1);
@@ -2963,7 +3085,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         client.add_member(&guild_id, &member, &Role::Member, &owner);
 
@@ -2984,7 +3107,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         client.add_member(&guild_id, &member, &Role::Member, &owner);
 
@@ -3002,7 +3126,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Initially should have 1 member (owner)
         let members = client.get_all_members(&guild_id);
@@ -3029,7 +3154,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         assert_eq!(client.is_member(&guild_id, &owner), true);
         assert_eq!(client.is_member(&guild_id, &member), false);
@@ -3052,7 +3178,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         client.add_member(&guild_id, &admin, &Role::Admin, &owner);
         client.add_member(&guild_id, &member, &Role::Member, &owner);
@@ -3132,7 +3259,8 @@ mod tests {
 
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         client.add_member(&guild_id, &admin, &Role::Admin, &owner);
 
@@ -3154,7 +3282,8 @@ mod tests {
 
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         client.add_member(&guild_id, &admin, &Role::Admin, &owner);
         client.add_member(&guild_id, &member, &Role::Member, &owner);
@@ -3178,7 +3307,8 @@ mod tests {
 
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         client.add_member(&guild_id, &admin, &Role::Admin, &owner);
 
@@ -3237,7 +3367,8 @@ mod tests {
         let name = String::from_str(&env, "Community Guild");
         let description = String::from_str(&env, "A thriving community");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
         assert_eq!(guild_id, 1u64);
 
         // Add admin
@@ -3276,7 +3407,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add admin
         client.add_member(&guild_id, &admin, &Role::Admin, &owner);
@@ -3305,7 +3437,8 @@ mod tests {
         let name = String::from_str(&env, "Guild");
         let description = String::from_str(&env, "Description");
 
-        let guild_id = client.create_guild(&name, &description, &owner);
+        let guild_id =
+            client.create_guild(&name, &description, &owner, &Some(valid_proof(&env, 9000)));
 
         // Add admin
         client.add_member(&guild_id, &admin, &Role::Admin, &owner);

--- a/contract/src/milestone/tests.rs
+++ b/contract/src/milestone/tests.rs
@@ -1,4 +1,4 @@
-﻿//! Milestone Tracking Contract Tests
+//! Milestone Tracking Contract Tests
 //!
 //! Comprehensive test coverage for project creation, milestone management,
 //! sequential/parallel flows, submissions, approvals, and progress tracking.
@@ -7,6 +7,7 @@
 
 use crate::guild::types::Role;
 use crate::milestone::types::{MilestoneInput, MilestoneStatus};
+use crate::InitializerProof;
 use crate::StellarGuildsContract;
 use crate::StellarGuildsContractClient;
 use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
@@ -43,7 +44,7 @@ fn register_and_init_contract(env: &Env) -> Address {
 fn setup_guild(client: &StellarGuildsContractClient<'_>, env: &Env, owner: &Address) -> u64 {
     let name = String::from_str(env, "Dev Guild");
     let description = String::from_str(env, "Developer Guild");
-    client.create_guild(&name, &description, owner)
+    client.create_guild(&name, &description, owner, &None::<InitializerProof>)
 }
 
 fn add_admin(

--- a/contract/src/multisig/tests.rs
+++ b/contract/src/multisig/tests.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::governance::{ProposalType, VoteDecision};
     use crate::multisig::types::{OperationStatus, OperationType, TIMEOUT_24H, TIMEOUT_48H};
+    use crate::InitializerProof;
     use crate::{StellarGuildsContract, StellarGuildsContractClient};
     use soroban_sdk::testutils::{Address as _, Ledger as _, LedgerInfo};
     use soroban_sdk::{Address, Env, String, Vec};
@@ -192,7 +193,8 @@ mod tests {
         // Treasury setup
         let guild_name = String::from_str(&env, "Treasury Guild");
         let guild_desc = String::from_str(&env, "Guild for treasury integration");
-        let guild_id = client.create_guild(&guild_name, &guild_desc, &owner);
+        let guild_id =
+            client.create_guild(&guild_name, &guild_desc, &owner, &None::<InitializerProof>);
 
         let mut treasury_signers = Vec::new(&env);
         treasury_signers.push_back(owner.clone());
@@ -235,7 +237,8 @@ mod tests {
 
         let guild_name = String::from_str(&env, "Gov Guild");
         let guild_desc = String::from_str(&env, "Guild for governance integration");
-        let guild_id = client.create_guild(&guild_name, &guild_desc, &owner);
+        let guild_id =
+            client.create_guild(&guild_name, &guild_desc, &owner, &None::<InitializerProof>);
 
         let title = String::from_str(&env, "General decision");
         let description = String::from_str(&env, "Should we proceed?");

--- a/contract/src/reputation/tests.rs
+++ b/contract/src/reputation/tests.rs
@@ -1,7 +1,8 @@
-﻿#[cfg(test)]
+#[cfg(test)]
 mod tests {
     use crate::guild::types::Role;
     use crate::reputation::types::{BadgeType, ContributionType};
+    use crate::InitializerProof;
     use crate::StellarGuildsContract;
     use crate::StellarGuildsContractClient;
     use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
@@ -36,7 +37,7 @@ mod tests {
     fn setup_guild(client: &StellarGuildsContractClient<'_>, env: &Env, owner: &Address) -> u64 {
         let name = String::from_str(env, "Test Guild");
         let description = String::from_str(env, "A test guild");
-        client.create_guild(&name, &description, owner)
+        client.create_guild(&name, &description, owner, &None::<InitializerProof>)
     }
 
     #[test]

--- a/contract/src/spam_protection/mod.rs
+++ b/contract/src/spam_protection/mod.rs
@@ -1,0 +1,9 @@
+/// Anti-spam Proof-of-Work gate for guild initialization.
+///
+/// Provides [`verification::verify_proof`] which is called inside
+/// `create_guild` to reject bot-driven guild-creation floods.
+pub mod types;
+pub mod verification;
+
+pub use types::{InitializerProof, SpamError};
+pub use verification::verify_proof;

--- a/contract/src/spam_protection/types.rs
+++ b/contract/src/spam_protection/types.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::{contracterror, contracttype, Bytes};
+
+/// Error returned when guild initialization proof is missing or invalid.
+///
+/// Returned as a contract panic with a well-known discriminant so callers
+/// can distinguish spam rejections from other errors.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SpamError {
+    /// `initializer_proof` was not provided (empty bytes).
+    MissingProof = 1,
+    /// The supplied proof hash does not meet the required difficulty.
+    InvalidProof = 2,
+    /// The nonce encoded in the proof has already been used.
+    NonceReused = 3,
+}
+
+/// Proof-of-Work token submitted alongside guild initialization.
+///
+/// The proof is a raw SHA-256 hash of `(sender_address_bytes || nonce_bytes)`
+/// that must begin with at least `POW_LEADING_ZERO_BITS` zero bits.
+///
+/// # On-chain computation note
+/// The contract does **not** compute the hash itself (no SHA-256 host function
+/// is exposed by Soroban at this time).  Instead it verifies that the supplied
+/// `hash` satisfies the difficulty requirement and that the nonce has not been
+/// used before.  The client (off-chain) performs the actual mining.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct InitializerProof {
+    /// SHA-256( address_bytes || nonce ) produced off-chain.
+    pub hash: Bytes,
+    /// Unique counter chosen by the miner; stored on-chain to prevent reuse.
+    pub nonce: u64,
+}

--- a/contract/src/spam_protection/verification.rs
+++ b/contract/src/spam_protection/verification.rs
@@ -1,0 +1,226 @@
+use soroban_sdk::{symbol_short, Bytes, Env, Map, Symbol};
+
+use crate::spam_protection::types::{InitializerProof, SpamError};
+
+/// Number of leading zero *bits* required in the proof hash.
+///
+/// Each additional bit doubles the expected mining work.
+/// 16 bits  ≈ 65 536 attempts on average — cheap for a human, expensive for a bot.
+/// Adjust via the `POW_DIFFICULTY` compile-time constant if needed.
+pub const POW_LEADING_ZERO_BITS: u32 = 16;
+
+/// Storage key for the used-nonces map.
+const USED_NONCES_KEY: Symbol = symbol_short!("pow_used");
+
+// ─── Public verification entry point ─────────────────────────────────────────
+
+/// Verify an `InitializerProof` for the given `creator` address.
+///
+/// Steps:
+///   1. Reject empty / missing proof.
+///   2. Check that the hash has the required number of leading zero bits.
+///   3. Check that the nonce has not been used before (replay protection).
+///   4. Persist the nonce so it cannot be reused.
+///
+/// # Errors
+/// Returns [`SpamError`] on any failure.  Callers should `panic!` with the
+/// error code so that the Soroban runtime surfaces it as a `ContractError`.
+pub fn verify_proof(env: &Env, proof: &InitializerProof) -> Result<(), SpamError> {
+    // ── 1. Reject empty proof ────────────────────────────────────────────
+    if proof.hash.is_empty() {
+        return Err(SpamError::MissingProof);
+    }
+
+    // ── 2. Difficulty check ──────────────────────────────────────────────
+    if !meets_difficulty(&proof.hash, POW_LEADING_ZERO_BITS) {
+        return Err(SpamError::InvalidProof);
+    }
+
+    // ── 3. Nonce replay check ────────────────────────────────────────────
+    let mut used: Map<u64, bool> = env
+        .storage()
+        .persistent()
+        .get(&USED_NONCES_KEY)
+        .unwrap_or_else(|| Map::new(env));
+
+    if used.contains_key(proof.nonce) {
+        return Err(SpamError::NonceReused);
+    }
+
+    // ── 4. Persist nonce ─────────────────────────────────────────────────
+    used.set(proof.nonce, true);
+    env.storage().persistent().set(&USED_NONCES_KEY, &used);
+
+    Ok(())
+}
+
+// ─── Difficulty helper ────────────────────────────────────────────────────────
+
+/// Returns `true` if the first `required_zero_bits` bits of `hash` are all 0.
+///
+/// Works on raw bytes — no SHA-256 host function is needed.
+fn meets_difficulty(hash: &Bytes, required_zero_bits: u32) -> bool {
+    if required_zero_bits == 0 {
+        return true;
+    }
+
+    let full_zero_bytes = (required_zero_bits / 8) as usize;
+    let remaining_bits = required_zero_bits % 8;
+
+    // Check completely-zero bytes
+    for i in 0..full_zero_bytes {
+        let byte = hash.get(i as u32).unwrap_or(0xff);
+        if byte != 0 {
+            return false;
+        }
+    }
+
+    // Check the partially-zero byte (high bits must be 0)
+    if remaining_bits > 0 {
+        let mask: u8 = 0xff_u8 << (8 - remaining_bits); // top N bits set
+        let byte = hash.get(full_zero_bytes as u32).unwrap_or(0xff);
+        if byte & mask != 0 {
+            return false;
+        }
+    }
+
+    true
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{Bytes, Env};
+
+    /// Build a `Bytes` value from a fixed-size array literal.
+    fn bytes_from_slice(env: &Env, data: &[u8]) -> Bytes {
+        Bytes::from_slice(env, data)
+    }
+
+    // Helper: produce a 32-byte hash with a given first byte, rest zeroed.
+    fn hash_with_first_byte(env: &Env, first: u8) -> Bytes {
+        let mut raw = [0u8; 32];
+        raw[0] = first;
+        bytes_from_slice(env, &raw)
+    }
+
+    #[test]
+    fn test_meets_difficulty_all_zeros_passes() {
+        let env = Env::default();
+        let hash = bytes_from_slice(&env, &[0u8; 32]);
+        assert!(meets_difficulty(&hash, 16));
+        assert!(meets_difficulty(&hash, 24));
+    }
+
+    #[test]
+    fn test_meets_difficulty_first_byte_nonzero_fails() {
+        let env = Env::default();
+        let hash = hash_with_first_byte(&env, 0x01);
+        assert!(!meets_difficulty(&hash, 16)); // first 16 bits must be 0
+    }
+
+    #[test]
+    fn test_meets_difficulty_partial_byte() {
+        let env = Env::default();
+        // 0x0F = 0000_1111: first 4 bits are zero → passes 4-bit requirement
+        let hash = bytes_from_slice(
+            &env,
+            &[0x00, 0x0f, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        );
+        assert!(meets_difficulty(&hash, 12)); // 1 zero byte + 4 zero bits in byte[1]
+        assert!(!meets_difficulty(&hash, 13)); // byte[1] bit 4 is set → fails 13-bit check
+    }
+
+    #[test]
+    fn test_meets_difficulty_zero_requirement_always_passes() {
+        let env = Env::default();
+        let hash = bytes_from_slice(&env, &[0xff; 32]);
+        assert!(meets_difficulty(&hash, 0));
+    }
+
+    #[test]
+    fn test_empty_proof_returns_missing_error() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        let contract = env.register_contract(None, crate::StellarGuildsContract);
+        env.as_contract(&contract, || {
+            let proof = InitializerProof {
+                hash: Bytes::new(&env),
+                nonce: 42,
+            };
+            assert_eq!(verify_proof(&env, &proof), Err(SpamError::MissingProof));
+        });
+    }
+
+    #[test]
+    fn test_insufficient_difficulty_returns_invalid_proof() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        let contract = env.register_contract(None, crate::StellarGuildsContract);
+        env.as_contract(&contract, || {
+            // Hash with non-zero first byte: difficulty 16 fails.
+            let proof = InitializerProof {
+                hash: hash_with_first_byte(&env, 0x01),
+                nonce: 1,
+            };
+            assert_eq!(verify_proof(&env, &proof), Err(SpamError::InvalidProof));
+        });
+    }
+
+    #[test]
+    fn test_valid_proof_accepted() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        let contract = env.register_contract(None, crate::StellarGuildsContract);
+        env.as_contract(&contract, || {
+            // All-zero hash passes any difficulty.
+            let proof = InitializerProof {
+                hash: bytes_from_slice(&env, &[0u8; 32]),
+                nonce: 99,
+            };
+            assert_eq!(verify_proof(&env, &proof), Ok(()));
+        });
+    }
+
+    #[test]
+    fn test_nonce_reuse_rejected() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        let contract = env.register_contract(None, crate::StellarGuildsContract);
+        env.as_contract(&contract, || {
+            let proof = InitializerProof {
+                hash: bytes_from_slice(&env, &[0u8; 32]),
+                nonce: 7,
+            };
+            // First use succeeds.
+            assert_eq!(verify_proof(&env, &proof), Ok(()));
+            // Second use with same nonce fails.
+            let proof2 = InitializerProof {
+                hash: bytes_from_slice(&env, &[0u8; 32]),
+                nonce: 7,
+            };
+            assert_eq!(verify_proof(&env, &proof2), Err(SpamError::NonceReused));
+        });
+    }
+
+    #[test]
+    fn test_different_nonces_both_accepted() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        let contract = env.register_contract(None, crate::StellarGuildsContract);
+        env.as_contract(&contract, || {
+            let proof_a = InitializerProof {
+                hash: bytes_from_slice(&env, &[0u8; 32]),
+                nonce: 100,
+            };
+            let proof_b = InitializerProof {
+                hash: bytes_from_slice(&env, &[0u8; 32]),
+                nonce: 101,
+            };
+            assert_eq!(verify_proof(&env, &proof_a), Ok(()));
+            assert_eq!(verify_proof(&env, &proof_b), Ok(()));
+        });
+    }
+}

--- a/contract/src/treasury/tests.rs
+++ b/contract/src/treasury/tests.rs
@@ -1,6 +1,7 @@
-﻿#[cfg(test)]
+#[cfg(test)]
 mod tests {
     use crate::treasury::types::{Allowance, TransactionStatus, TransactionType, Treasury};
+    use crate::InitializerProof;
     use crate::StellarGuildsContract;
     use crate::StellarGuildsContractClient;
     use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
@@ -35,7 +36,7 @@ mod tests {
     fn setup_guild(client: &StellarGuildsContractClient<'_>, env: &Env, owner: &Address) -> u64 {
         let name = String::from_str(env, "Test Guild");
         let description = String::from_str(env, "A test guild");
-        client.create_guild(&name, &description, owner)
+        client.create_guild(&name, &description, owner, &None::<InitializerProof>)
     }
 
     fn create_treasury(

--- a/contract/src/upgrade_mfa/logic.rs
+++ b/contract/src/upgrade_mfa/logic.rs
@@ -1,0 +1,317 @@
+use soroban_sdk::{Address, Env, String};
+
+use crate::upgrade_mfa::storage;
+use crate::upgrade_mfa::types::{UpgradeMfaError, UpgradePendingState};
+
+/// How long (in seconds) the second signature window stays open after the first.
+/// Default: 1 hour.  Adjust as needed.
+pub const SECOND_SIG_WINDOW_SECS: u64 = 3_600;
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+/// Register the primary admin and the backup signing key.
+///
+/// Should be called once during contract initialization or by a governance
+/// proposal.  Both addresses must sign so neither can be set unilaterally.
+pub fn initialize_mfa(env: &Env, admin: &Address, backup_key: &Address) {
+    admin.require_auth();
+    backup_key.require_auth();
+    storage::set_admin(env, admin);
+    storage::set_backup_key(env, backup_key);
+}
+
+// ─── Step 1: Admin proposes upgrade ──────────────────────────────────────────
+
+/// Record the first signature for a sensitive upgrade action.
+///
+/// Sets `upgrade_pending = true` and stores the proposal metadata.
+/// The second signature from `backup_key` must arrive within
+/// [`SECOND_SIG_WINDOW_SECS`] seconds or the proposal expires.
+///
+/// # Errors
+/// - [`UpgradeMfaError::NotInitialized`] — MFA not set up yet.
+/// - [`UpgradeMfaError::NotAdmin`] — `caller` is not the registered admin.
+/// - [`UpgradeMfaError::AlreadyPending`] — a previous proposal is still open.
+pub fn upgrade_first_signature(
+    env: &Env,
+    caller: &Address,
+    description: String,
+) -> Result<(), UpgradeMfaError> {
+    caller.require_auth();
+
+    let admin = storage::get_admin(env).ok_or(UpgradeMfaError::NotInitialized)?;
+    if *caller != admin {
+        return Err(UpgradeMfaError::NotAdmin);
+    }
+
+    if storage::is_pending(env) {
+        // Lazily check expiry before rejecting: if the previous proposal
+        // has already expired we allow a fresh one to be created.
+        if let Some(pending) = storage::get_pending(env) {
+            if env.ledger().timestamp() <= pending.expires_at {
+                return Err(UpgradeMfaError::AlreadyPending);
+            }
+            // Expired — silently clear and proceed.
+            storage::clear_pending(env);
+        }
+    }
+
+    let expires_at = env.ledger().timestamp() + SECOND_SIG_WINDOW_SECS;
+    storage::store_pending(
+        env,
+        &UpgradePendingState {
+            proposed_by: caller.clone(),
+            expires_at,
+            description,
+        },
+    );
+
+    Ok(())
+}
+
+// ─── Step 2: Backup key confirms upgrade ─────────────────────────────────────
+
+/// Provide the second (backup-key) signature to complete a pending upgrade.
+///
+/// Executes the upgrade if the proposal is still within the time window.
+/// Clears `upgrade_pending` regardless of outcome (success or expiry).
+///
+/// # Errors
+/// - [`UpgradeMfaError::NotInitialized`] — MFA not set up yet.
+/// - [`UpgradeMfaError::NotBackupKey`] — `caller` is not the registered backup key.
+/// - [`UpgradeMfaError::NoPendingUpgrade`] — no proposal is open.
+/// - [`UpgradeMfaError::UpgradeExpired`] — the proposal's time window closed.
+pub fn upgrade_second_signature(
+    env: &Env,
+    caller: &Address,
+) -> Result<UpgradePendingState, UpgradeMfaError> {
+    caller.require_auth();
+
+    let backup = storage::get_backup_key(env).ok_or(UpgradeMfaError::NotInitialized)?;
+    if *caller != backup {
+        return Err(UpgradeMfaError::NotBackupKey);
+    }
+
+    let pending = storage::get_pending(env).ok_or(UpgradeMfaError::NoPendingUpgrade)?;
+
+    // Time-window check — clear regardless so expired proposals are GC'd.
+    if env.ledger().timestamp() > pending.expires_at {
+        storage::clear_pending(env);
+        return Err(UpgradeMfaError::UpgradeExpired);
+    }
+
+    // Both signatures collected — clear pending flag and return the approved state.
+    storage::clear_pending(env);
+    Ok(pending)
+}
+
+// ─── Query ────────────────────────────────────────────────────────────────────
+
+/// Returns whether an upgrade is currently pending a second signature.
+pub fn is_upgrade_pending(env: &Env) -> bool {
+    if !storage::is_pending(env) {
+        return false;
+    }
+    // Lazily expire
+    if let Some(pending) = storage::get_pending(env) {
+        if env.ledger().timestamp() > pending.expires_at {
+            storage::clear_pending(env);
+            return false;
+        }
+    }
+    true
+}
+
+/// Returns the pending upgrade proposal if one is active and not expired.
+pub fn get_pending_upgrade(env: &Env) -> Option<UpgradePendingState> {
+    let pending = storage::get_pending(env)?;
+    if env.ledger().timestamp() > pending.expires_at {
+        storage::clear_pending(env);
+        return None;
+    }
+    Some(pending)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::StellarGuildsContract;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, Env, String};
+
+    fn setup() -> (Env, Address, Address, Address) {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+        let contract = env.register_contract(None, StellarGuildsContract);
+        let admin = Address::generate(&env);
+        let backup = Address::generate(&env);
+        (env, contract, admin, backup)
+    }
+
+    fn init(env: &Env, contract: &Address, admin: &Address, backup: &Address) {
+        env.as_contract(contract, || {
+            initialize_mfa(env, admin, backup);
+        });
+    }
+
+    fn desc(env: &Env, s: &str) -> String {
+        String::from_str(env, s)
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    /// Full two-step flow: admin proposes, backup confirms within the window.
+    #[test]
+    fn test_two_step_upgrade_success() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+
+        env.as_contract(&contract, || {
+            // Step 1 — admin submits first signature
+            assert_eq!(
+                upgrade_first_signature(&env, &admin, desc(&env, "upgrade to v2.0")),
+                Ok(())
+            );
+            assert!(is_upgrade_pending(&env), "upgrade should be pending after step 1");
+
+            // Step 2 — backup key confirms
+            let result = upgrade_second_signature(&env, &backup);
+            assert!(result.is_ok(), "second signature should succeed");
+
+            let approved = result.unwrap();
+            assert_eq!(approved.proposed_by, admin);
+            assert!(!is_upgrade_pending(&env), "pending flag should be cleared after step 2");
+        });
+    }
+
+    /// Second signature from a non-backup address must be rejected.
+    #[test]
+    fn test_second_sig_wrong_caller_rejected() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+        let impostor = Address::generate(&env);
+
+        env.as_contract(&contract, || {
+            upgrade_first_signature(&env, &admin, desc(&env, "upgrade")).unwrap();
+            let err = upgrade_second_signature(&env, &impostor).unwrap_err();
+            assert_eq!(err, UpgradeMfaError::NotBackupKey);
+            // Pending state untouched
+            assert!(is_upgrade_pending(&env));
+        });
+    }
+
+    /// First signature from a non-admin address must be rejected.
+    #[test]
+    fn test_first_sig_wrong_caller_rejected() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+        let impostor = Address::generate(&env);
+
+        env.as_contract(&contract, || {
+            let err = upgrade_first_signature(&env, &impostor, desc(&env, "attack")).unwrap_err();
+            assert_eq!(err, UpgradeMfaError::NotAdmin);
+            assert!(!is_upgrade_pending(&env));
+        });
+    }
+
+    // ── Expiry ────────────────────────────────────────────────────────────────
+
+    /// Second signature after the expiry window must return `UpgradeExpired`
+    /// and clear the pending flag.
+    #[test]
+    fn test_second_sig_after_expiry_rejected() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+
+        env.as_contract(&contract, || {
+            upgrade_first_signature(&env, &admin, desc(&env, "upgrade")).unwrap();
+
+            // Advance ledger time past the window.
+            env.ledger().with_mut(|li| {
+                li.timestamp = li.timestamp + SECOND_SIG_WINDOW_SECS + 1;
+            });
+
+            let err = upgrade_second_signature(&env, &backup).unwrap_err();
+            assert_eq!(err, UpgradeMfaError::UpgradeExpired);
+            assert!(!is_upgrade_pending(&env), "expired proposal should be cleared");
+        });
+    }
+
+    /// After an expired proposal is cleared, a new proposal can be created.
+    #[test]
+    fn test_new_proposal_allowed_after_expiry() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+
+        env.as_contract(&contract, || {
+            upgrade_first_signature(&env, &admin, desc(&env, "first attempt")).unwrap();
+
+            // Expire the first proposal.
+            env.ledger().with_mut(|li| {
+                li.timestamp = li.timestamp + SECOND_SIG_WINDOW_SECS + 1;
+            });
+
+            // A fresh proposal should succeed (expired one is lazily cleared).
+            assert_eq!(
+                upgrade_first_signature(&env, &admin, desc(&env, "second attempt")),
+                Ok(())
+            );
+        });
+    }
+
+    // ── Guard rails ───────────────────────────────────────────────────────────
+
+    /// Proposing when a non-expired proposal is already pending must return
+    /// `AlreadyPending`.
+    #[test]
+    fn test_duplicate_proposal_rejected() {
+        let (env, contract, admin, backup) = setup();
+        let _ = backup;
+        init(&env, &contract, &admin, &backup);
+
+        env.as_contract(&contract, || {
+            upgrade_first_signature(&env, &admin, desc(&env, "first")).unwrap();
+            let err =
+                upgrade_first_signature(&env, &admin, desc(&env, "second")).unwrap_err();
+            assert_eq!(err, UpgradeMfaError::AlreadyPending);
+        });
+    }
+
+    /// Calling `upgrade_second_signature` when no proposal exists must return
+    /// `NoPendingUpgrade`.
+    #[test]
+    fn test_second_sig_without_first_sig_rejected() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+
+        env.as_contract(&contract, || {
+            let err = upgrade_second_signature(&env, &backup).unwrap_err();
+            assert_eq!(err, UpgradeMfaError::NoPendingUpgrade);
+        });
+    }
+
+    /// Calling either function before `initialize_mfa` must return
+    /// `NotInitialized`.
+    #[test]
+    fn test_operations_without_initialization_rejected() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+        let contract = env.register_contract(None, StellarGuildsContract);
+        let caller = Address::generate(&env);
+
+        env.as_contract(&contract, || {
+            assert_eq!(
+                upgrade_first_signature(&env, &caller, desc(&env, "x")),
+                Err(UpgradeMfaError::NotInitialized)
+            );
+            assert_eq!(
+                upgrade_second_signature(&env, &caller),
+                Err(UpgradeMfaError::NotInitialized)
+            );
+        });
+    }
+}

--- a/contract/src/upgrade_mfa/mod.rs
+++ b/contract/src/upgrade_mfa/mod.rs
@@ -1,0 +1,328 @@
+mod storage;
+mod types;
+
+use soroban_sdk::{Address, Env, String};
+
+pub use types::{UpgradeMfaError, UpgradePendingState};
+
+/// How long (in seconds) the second signature window stays open after the first.
+/// Default: 1 hour.  Adjust as needed.
+pub const SECOND_SIG_WINDOW_SECS: u64 = 3_600;
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+/// Register the primary admin and the backup signing key.
+///
+/// Should be called once during contract initialization or by a governance
+/// proposal.  Both addresses must sign so neither can be set unilaterally.
+pub fn initialize_mfa(env: &Env, admin: &Address, backup_key: &Address) {
+    admin.require_auth();
+    backup_key.require_auth();
+    storage::set_admin(env, admin);
+    storage::set_backup_key(env, backup_key);
+}
+
+// ─── Step 1: Admin proposes upgrade ──────────────────────────────────────────
+
+/// Record the first signature for a sensitive upgrade action.
+///
+/// Sets `upgrade_pending = true` and stores the proposal metadata.
+/// The second signature from `backup_key` must arrive within
+/// [`SECOND_SIG_WINDOW_SECS`] seconds or the proposal expires.
+///
+/// # Errors
+/// - [`UpgradeMfaError::NotInitialized`] — MFA not set up yet.
+/// - [`UpgradeMfaError::NotAdmin`] — `caller` is not the registered admin.
+/// - [`UpgradeMfaError::AlreadyPending`] — a previous proposal is still open.
+pub fn upgrade_first_signature(
+    env: &Env,
+    caller: &Address,
+    description: String,
+) -> Result<(), UpgradeMfaError> {
+    let admin = storage::get_admin(env).ok_or(UpgradeMfaError::NotInitialized)?;
+
+    if *caller != admin {
+        return Err(UpgradeMfaError::NotAdmin);
+    }
+
+    if storage::is_pending(env) {
+        if let Some(pending) = storage::get_pending(env) {
+            if env.ledger().timestamp() <= pending.expires_at {
+                return Err(UpgradeMfaError::AlreadyPending);
+            }
+            storage::clear_pending(env);
+        }
+    }
+
+    caller.require_auth();
+
+    let expires_at = env.ledger().timestamp() + SECOND_SIG_WINDOW_SECS;
+    storage::store_pending(
+        env,
+        &UpgradePendingState {
+            proposed_by: caller.clone(),
+            expires_at,
+            description,
+        },
+    );
+
+    Ok(())
+}
+
+// ─── Step 2: Backup key confirms upgrade ─────────────────────────────────────
+
+/// Provide the second (backup-key) signature to complete a pending upgrade.
+///
+/// Executes the upgrade if the proposal is still within the time window.
+/// Clears `upgrade_pending` regardless of outcome (success or expiry).
+///
+/// # Errors
+/// - [`UpgradeMfaError::NotInitialized`] — MFA not set up yet.
+/// - [`UpgradeMfaError::NotBackupKey`] — `caller` is not the registered backup key.
+/// - [`UpgradeMfaError::NoPendingUpgrade`] — no proposal is open.
+/// - [`UpgradeMfaError::UpgradeExpired`] — the proposal's time window closed.
+pub fn upgrade_second_signature(
+    env: &Env,
+    caller: &Address,
+) -> Result<UpgradePendingState, UpgradeMfaError> {
+    let backup = storage::get_backup_key(env).ok_or(UpgradeMfaError::NotInitialized)?;
+
+    if *caller != backup {
+        return Err(UpgradeMfaError::NotBackupKey);
+    }
+
+    let pending = storage::get_pending(env).ok_or(UpgradeMfaError::NoPendingUpgrade)?;
+
+    if env.ledger().timestamp() > pending.expires_at {
+        storage::clear_pending(env);
+        return Err(UpgradeMfaError::UpgradeExpired);
+    }
+
+    caller.require_auth();
+
+    storage::clear_pending(env);
+    Ok(pending)
+}
+
+// ─── Query ────────────────────────────────────────────────────────────────────
+
+/// Returns whether an upgrade is currently pending a second signature.
+pub fn is_upgrade_pending(env: &Env) -> bool {
+    if !storage::is_pending(env) {
+        return false;
+    }
+    // Lazily expire
+    if let Some(pending) = storage::get_pending(env) {
+        if env.ledger().timestamp() > pending.expires_at {
+            storage::clear_pending(env);
+            return false;
+        }
+    }
+    true
+}
+
+/// Returns the pending upgrade proposal if one is active and not expired.
+pub fn get_pending_upgrade(env: &Env) -> Option<UpgradePendingState> {
+    let pending = storage::get_pending(env)?;
+    if env.ledger().timestamp() > pending.expires_at {
+        storage::clear_pending(env);
+        return None;
+    }
+    Some(pending)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::StellarGuildsContract;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::Ledger;
+    use soroban_sdk::{Address, Env, String};
+
+    fn setup() -> (Env, Address, Address, Address) {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+        let contract = env.register_contract(None, StellarGuildsContract);
+        let admin = Address::generate(&env);
+        let backup = Address::generate(&env);
+        (env, contract, admin, backup)
+    }
+
+    fn init(env: &Env, contract: &Address, admin: &Address, backup: &Address) {
+        env.as_contract(contract, || {
+            initialize_mfa(env, admin, backup);
+        });
+    }
+
+    fn desc(env: &Env, s: &str) -> String {
+        String::from_str(env, s)
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    /// Full two-step flow: admin proposes, backup confirms within the window.
+    #[test]
+    fn test_two_step_upgrade_success() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+
+        env.as_contract(&contract, || {
+            // Step 1 — admin submits first signature
+            assert_eq!(
+                upgrade_first_signature(&env, &admin, desc(&env, "upgrade to v2.0")),
+                Ok(())
+            );
+            assert!(
+                is_upgrade_pending(&env),
+                "upgrade should be pending after step 1"
+            );
+
+            // Step 2 — backup key confirms
+            let result = upgrade_second_signature(&env, &backup);
+            assert!(result.is_ok(), "second signature should succeed");
+
+            let approved = result.unwrap();
+            assert_eq!(approved.proposed_by, admin);
+            assert!(
+                !is_upgrade_pending(&env),
+                "pending flag should be cleared after step 2"
+            );
+        });
+    }
+
+    /// Second signature from a non-backup address must be rejected.
+    #[test]
+    fn test_second_sig_wrong_caller_rejected() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+        let impostor = Address::generate(&env);
+
+        env.as_contract(&contract, || {
+            upgrade_first_signature(&env, &admin, desc(&env, "upgrade")).unwrap();
+            let err = upgrade_second_signature(&env, &impostor).unwrap_err();
+            assert_eq!(err, UpgradeMfaError::NotBackupKey);
+            // Pending state untouched
+            assert!(is_upgrade_pending(&env));
+        });
+    }
+
+    /// First signature from a non-admin address must be rejected.
+    #[test]
+    fn test_first_sig_wrong_caller_rejected() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+        let impostor = Address::generate(&env);
+
+        env.as_contract(&contract, || {
+            let err = upgrade_first_signature(&env, &impostor, desc(&env, "attack")).unwrap_err();
+            assert_eq!(err, UpgradeMfaError::NotAdmin);
+            assert!(!is_upgrade_pending(&env));
+        });
+    }
+
+    // ── Expiry ────────────────────────────────────────────────────────────────
+
+    /// Second signature after the expiry window must return `UpgradeExpired`
+    /// and clear the pending flag.
+    #[test]
+    fn test_second_sig_after_expiry_rejected() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+
+        env.as_contract(&contract, || {
+            upgrade_first_signature(&env, &admin, desc(&env, "upgrade")).unwrap();
+
+            // Advance ledger time past the window.
+            env.ledger().with_mut(|li| {
+                li.timestamp = li.timestamp + SECOND_SIG_WINDOW_SECS + 1;
+            });
+
+            let err = upgrade_second_signature(&env, &backup).unwrap_err();
+            assert_eq!(err, UpgradeMfaError::UpgradeExpired);
+            assert!(
+                !is_upgrade_pending(&env),
+                "expired proposal should be cleared"
+            );
+        });
+    }
+
+    /// After an expired proposal is cleared, a new proposal can be created.
+    #[test]
+    fn test_new_proposal_allowed_after_expiry() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+
+        // Frame 1 — submit the first proposal
+        env.as_contract(&contract, || {
+            upgrade_first_signature(&env, &admin, desc(&env, "first attempt")).unwrap();
+        });
+
+        // Advance time outside the frame (this is fine)
+        env.ledger().with_mut(|li| {
+            li.timestamp = li.timestamp + SECOND_SIG_WINDOW_SECS + 1;
+        });
+
+        // Frame 2 — fresh auth token, expired proposal is lazily cleared, new one accepted
+        env.as_contract(&contract, || {
+            assert_eq!(
+                upgrade_first_signature(&env, &admin, desc(&env, "second attempt")),
+                Ok(())
+            );
+        });
+    }
+
+    // ── Guard rails ───────────────────────────────────────────────────────────
+
+    /// Proposing when a non-expired proposal is already pending must return
+    /// `AlreadyPending`.
+    #[test]
+    fn test_duplicate_proposal_rejected() {
+        let (env, contract, admin, backup) = setup();
+        let _ = backup;
+        init(&env, &contract, &admin, &backup);
+
+        env.as_contract(&contract, || {
+            upgrade_first_signature(&env, &admin, desc(&env, "first")).unwrap();
+            let err = upgrade_first_signature(&env, &admin, desc(&env, "second")).unwrap_err();
+            assert!(matches!(err, UpgradeMfaError::AlreadyPending));
+        });
+    }
+
+    /// Calling `upgrade_second_signature` when no proposal exists must return
+    /// `NoPendingUpgrade`.
+    #[test]
+    fn test_second_sig_without_first_sig_rejected() {
+        let (env, contract, admin, backup) = setup();
+        init(&env, &contract, &admin, &backup);
+
+        env.as_contract(&contract, || {
+            let err = upgrade_second_signature(&env, &backup).unwrap_err();
+            assert_eq!(err, UpgradeMfaError::NoPendingUpgrade);
+        });
+    }
+
+    /// Calling either function before `initialize_mfa` must return
+    /// `NotInitialized`.
+    #[test]
+    fn test_operations_without_initialization_rejected() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        env.mock_all_auths();
+        let contract = env.register_contract(None, StellarGuildsContract);
+        let caller = Address::generate(&env);
+
+        env.as_contract(&contract, || {
+            assert!(matches!(
+                upgrade_first_signature(&env, &caller, desc(&env, "x")),
+                Err(UpgradeMfaError::NotInitialized)
+            ));
+            assert!(matches!(
+                upgrade_second_signature(&env, &caller),
+                Err(UpgradeMfaError::NotInitialized)
+            ));
+        });
+    }
+}

--- a/contract/src/upgrade_mfa/storage.rs
+++ b/contract/src/upgrade_mfa/storage.rs
@@ -1,0 +1,49 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+use crate::upgrade_mfa::types::UpgradePendingState;
+
+const ADMIN_KEY: Symbol = symbol_short!("mfa_admin");
+const BACKUP_KEY: Symbol = symbol_short!("mfa_bkup");
+const PENDING_KEY: Symbol = symbol_short!("mfa_pend");
+const PENDING_FLAG_KEY: Symbol = symbol_short!("mfa_flag");
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().persistent().set(&ADMIN_KEY, admin);
+}
+
+pub fn get_admin(env: &Env) -> Option<Address> {
+    env.storage().persistent().get(&ADMIN_KEY)
+}
+
+pub fn set_backup_key(env: &Env, backup: &Address) {
+    env.storage().persistent().set(&BACKUP_KEY, backup);
+}
+
+pub fn get_backup_key(env: &Env) -> Option<Address> {
+    env.storage().persistent().get(&BACKUP_KEY)
+}
+
+// ─── Pending-upgrade state ────────────────────────────────────────────────────
+
+pub fn store_pending(env: &Env, state: &UpgradePendingState) {
+    env.storage().persistent().set(&PENDING_KEY, state);
+    env.storage().persistent().set(&PENDING_FLAG_KEY, &true);
+}
+
+pub fn get_pending(env: &Env) -> Option<UpgradePendingState> {
+    env.storage().persistent().get(&PENDING_KEY)
+}
+
+pub fn is_pending(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .get::<Symbol, bool>(&PENDING_FLAG_KEY)
+        .unwrap_or(false)
+}
+
+pub fn clear_pending(env: &Env) {
+    env.storage().persistent().remove(&PENDING_KEY);
+    env.storage().persistent().set(&PENDING_FLAG_KEY, &false);
+}

--- a/contract/src/upgrade_mfa/types.rs
+++ b/contract/src/upgrade_mfa/types.rs
@@ -1,0 +1,32 @@
+use soroban_sdk::{contracttype, Address};
+
+/// Error variants for the two-step upgrade MFA flow.
+#[soroban_sdk::contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum UpgradeMfaError {
+    /// Caller is not the primary admin address.
+    NotAdmin = 1,
+    /// Caller is not the secondary backup key address.
+    NotBackupKey = 2,
+    /// `upgrade_second_signature` was called but no pending upgrade exists.
+    NoPendingUpgrade = 3,
+    /// `upgrade_second_signature` was called but the proposal has expired.
+    UpgradeExpired = 4,
+    /// The upgrade system has not been initialized (no admin set).
+    NotInitialized = 5,
+    /// A pending upgrade already exists; cancel it before proposing a new one.
+    AlreadyPending = 6,
+}
+
+/// Persisted state of a two-step upgrade proposal.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct UpgradePendingState {
+    /// The admin address that submitted the first signature.
+    pub proposed_by: Address,
+    /// Ledger timestamp after which the second signature window closes.
+    pub expires_at: u64,
+    /// Free-form description of what is being upgraded (for audit).
+    pub description: soroban_sdk::String,
+}

--- a/contract/test_snapshots/bounty/tests/test_admin_can_approve_bounty.1.json
+++ b/contract/test_snapshots/bounty/tests/test_admin_can_approve_bounty.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1996,7 +1997,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_admin_can_cancel_bounty.1.json
+++ b/contract/test_snapshots/bounty/tests/test_admin_can_cancel_bounty.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1897,7 +1898,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_approve_completion_non_admin_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_approve_completion_non_admin_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1847,7 +1848,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_approve_completion_success.1.json
+++ b/contract/test_snapshots/bounty/tests/test_approve_completion_success.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1902,7 +1903,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_approve_completion_wrong_status_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_approve_completion_wrong_status_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1790,7 +1791,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_cancel_bounty_after_claim_refunds_creator.1.json
+++ b/contract/test_snapshots/bounty/tests/test_cancel_bounty_after_claim_refunds_creator.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1919,7 +1920,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_cancel_bounty_by_creator.1.json
+++ b/contract/test_snapshots/bounty/tests/test_cancel_bounty_by_creator.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1804,7 +1805,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_cancel_bounty_completed_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_cancel_bounty_completed_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1902,7 +1903,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_cancel_bounty_non_creator_non_admin_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_cancel_bounty_non_creator_non_admin_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1386,7 +1387,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_claim_bounty_already_claimed_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_claim_bounty_already_claimed_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1790,7 +1791,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_claim_bounty_not_open_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_claim_bounty_not_open_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1386,7 +1387,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_claim_bounty_success.1.json
+++ b/contract/test_snapshots/bounty/tests/test_claim_bounty_success.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1790,7 +1791,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_create_bounty_empty_title_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_create_bounty_empty_title_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1091,7 +1092,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_create_bounty_negative_reward_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_create_bounty_negative_reward_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1091,7 +1092,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_create_bounty_non_admin_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_create_bounty_non_admin_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1091,7 +1092,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_create_bounty_past_expiry_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_create_bounty_past_expiry_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1091,7 +1092,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_create_bounty_success.1.json
+++ b/contract/test_snapshots/bounty/tests/test_create_bounty_success.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1386,7 +1387,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_create_bounty_zero_reward_is_open.1.json
+++ b/contract/test_snapshots/bounty/tests/test_create_bounty_zero_reward_is_open.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1386,7 +1387,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_expire_bounty_not_expired_yet.1.json
+++ b/contract/test_snapshots/bounty/tests/test_expire_bounty_not_expired_yet.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1676,7 +1677,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_expire_bounty_success.1.json
+++ b/contract/test_snapshots/bounty/tests/test_expire_bounty_success.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1750,7 +1751,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_full_bounty_lifecycle.1.json
+++ b/contract/test_snapshots/bounty/tests/test_full_bounty_lifecycle.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1983,7 +1984,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_fund_bounty_partial_funding.1.json
+++ b/contract/test_snapshots/bounty/tests/test_fund_bounty_partial_funding.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1761,7 +1762,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_fund_bounty_success.1.json
+++ b/contract/test_snapshots/bounty/tests/test_fund_bounty_success.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1675,7 +1676,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_fund_bounty_zero_amount_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_fund_bounty_zero_amount_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1386,7 +1387,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_get_guild_bounties.1.json
+++ b/contract/test_snapshots/bounty/tests/test_get_guild_bounties.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1768,7 +1769,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_multiple_bounties_per_guild.1.json
+++ b/contract/test_snapshots/bounty/tests/test_multiple_bounties_per_guild.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2527,7 +2528,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_release_escrow_not_completed_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_release_escrow_not_completed_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1790,7 +1791,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_release_escrow_success.1.json
+++ b/contract/test_snapshots/bounty/tests/test_release_escrow_success.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1976,7 +1977,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_submit_work_no_claimer_fails.1.json
+++ b/contract/test_snapshots/bounty/tests/test_submit_work_no_claimer_fails.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1675,7 +1676,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/bounty/tests/test_submit_work_success.1.json
+++ b/contract/test_snapshots/bounty/tests/test_submit_work_success.1.json
@@ -41,7 +41,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1847,7 +1848,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_cast_vote_weighted_and_quorum.1.json
+++ b/contract/test_snapshots/dispute/tests/test_cast_vote_weighted_and_quorum.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2554,7 +2555,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_concurrent_disputes_blocked.1.json
+++ b/contract/test_snapshots/dispute/tests/test_concurrent_disputes_blocked.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2181,7 +2182,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_create_dispute_bounty_success.1.json
+++ b/contract/test_snapshots/dispute/tests/test_create_dispute_bounty_success.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2180,7 +2181,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_create_dispute_milestone_success.1.json
+++ b/contract/test_snapshots/dispute/tests/test_create_dispute_milestone_success.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1950,7 +1951,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_dispute_status_updates_after_resolution.1.json
+++ b/contract/test_snapshots/dispute/tests/test_dispute_status_updates_after_resolution.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2514,7 +2515,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_double_vote_fails.1.json
+++ b/contract/test_snapshots/dispute/tests/test_double_vote_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2340,7 +2341,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_insufficient_quorum_expires_and_refunds_creator.1.json
+++ b/contract/test_snapshots/dispute/tests/test_insufficient_quorum_expires_and_refunds_creator.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2324,7 +2325,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_non_member_vote_fails.1.json
+++ b/contract/test_snapshots/dispute/tests/test_non_member_vote_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2181,7 +2182,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_resolve_dispute_tie_splits_funds.1.json
+++ b/contract/test_snapshots/dispute/tests/test_resolve_dispute_tie_splits_funds.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2611,7 +2612,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_self_voting_fails.1.json
+++ b/contract/test_snapshots/dispute/tests/test_self_voting_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2181,7 +2182,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_submit_evidence_non_party_fails.1.json
+++ b/contract/test_snapshots/dispute/tests/test_submit_evidence_non_party_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2181,7 +2182,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/dispute/tests/test_voting_deadline_enforced.1.json
+++ b/contract/test_snapshots/dispute/tests/test_voting_deadline_enforced.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2181,7 +2182,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/governance/tests/tests/test_create_proposal_basic.1.json
+++ b/contract/test_snapshots/governance/tests/tests/test_create_proposal_basic.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1382,7 +1383,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/governance/tests/tests/test_quorum_rejection_prevents_execution.1.json
+++ b/contract/test_snapshots/governance/tests/tests/test_quorum_rejection_prevents_execution.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1543,7 +1544,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/governance/tests/tests/test_vote_delegation_and_execution.1.json
+++ b/contract/test_snapshots/governance/tests/tests/test_vote_delegation_and_execution.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1780,7 +1781,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/governance/tests/tests/test_vote_weights_and_execution.1.json
+++ b/contract/test_snapshots/governance/tests/tests/test_vote_weights_and_execution.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1957,7 +1958,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_add_milestone_non_admin_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_add_milestone_non_admin_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1325,7 +1326,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_add_milestone_to_existing_project.1.json
+++ b/contract/test_snapshots/milestone/tests/test_add_milestone_to_existing_project.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1562,7 +1563,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_approve_milestone_non_admin_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_approve_milestone_non_admin_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1383,7 +1384,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_approve_milestone_not_submitted_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_approve_milestone_not_submitted_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1380,7 +1381,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_approve_milestone_success.1.json
+++ b/contract/test_snapshots/milestone/tests/test_approve_milestone_success.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2426,7 +2427,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_cancel_project.1.json
+++ b/contract/test_snapshots/milestone/tests/test_cancel_project.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1379,7 +1380,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_cancel_project_non_admin_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_cancel_project_non_admin_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1325,7 +1326,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_create_project_no_milestones_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_create_project_no_milestones_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -779,7 +780,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_create_project_overallocated_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_create_project_overallocated_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -779,7 +780,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_create_project_past_deadline_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_create_project_past_deadline_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -779,7 +780,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_create_project_success.1.json
+++ b/contract/test_snapshots/milestone/tests/test_create_project_success.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1530,7 +1531,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_create_project_zero_amount_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_create_project_zero_amount_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -779,7 +780,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_extend_milestone_deadline.1.json
+++ b/contract/test_snapshots/milestone/tests/test_extend_milestone_deadline.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1383,7 +1384,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_parallel_allows_any_order.1.json
+++ b/contract/test_snapshots/milestone/tests/test_parallel_allows_any_order.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1584,7 +1585,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_progress_calculation.1.json
+++ b/contract/test_snapshots/milestone/tests/test_progress_calculation.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -3178,7 +3179,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_reject_milestone_success.1.json
+++ b/contract/test_snapshots/milestone/tests/test_reject_milestone_success.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1535,7 +1536,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_resubmit_after_rejection.1.json
+++ b/contract/test_snapshots/milestone/tests/test_resubmit_after_rejection.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1443,7 +1444,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_sequential_allows_second_after_first_approved.1.json
+++ b/contract/test_snapshots/milestone/tests/test_sequential_allows_second_after_first_approved.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2593,7 +2594,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_sequential_prevents_out_of_order_start.1.json
+++ b/contract/test_snapshots/milestone/tests/test_sequential_prevents_out_of_order_start.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1530,7 +1531,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_start_milestone_success.1.json
+++ b/contract/test_snapshots/milestone/tests/test_start_milestone_success.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1380,7 +1381,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_start_milestone_wrong_contributor_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_start_milestone_wrong_contributor_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1325,7 +1326,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_submit_milestone_before_starting_fails.1.json
+++ b/contract/test_snapshots/milestone/tests/test_submit_milestone_before_starting_fails.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1325,7 +1326,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/milestone/tests/test_submit_milestone_success.1.json
+++ b/contract/test_snapshots/milestone/tests/test_submit_milestone_success.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1383,7 +1384,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/multisig/tests/tests/test_governance_multisig_gate_integration.1.json
+++ b/contract/test_snapshots/multisig/tests/tests/test_governance_multisig_gate_integration.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1837,7 +1838,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/multisig/tests/tests/test_treasury_withdrawal_multisig_gate_integration.1.json
+++ b/contract/test_snapshots/multisig/tests/tests/test_treasury_withdrawal_multisig_gate_integration.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2162,7 +2163,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/tests/test_add_admin_by_non_owner.1.json
+++ b/contract/test_snapshots/tests/test_add_admin_by_non_owner.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -523,6 +543,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -873,6 +933,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1260,7 +1340,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'add_member error' from contract function 'Symbol(obj#263)'"
+                  "string": "caught panic 'add_member error' from contract function 'Symbol(obj#271)'"
                 },
                 {
                   "u64": 1

--- a/contract/test_snapshots/tests/test_add_member_by_owner.1.json
+++ b/contract/test_snapshots/tests/test_add_member_by_owner.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -523,6 +543,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -873,6 +933,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_add_member_duplicate.1.json
+++ b/contract/test_snapshots/tests/test_add_member_duplicate.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -523,6 +543,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -873,6 +933,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1260,7 +1340,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'add_member error' from contract function 'Symbol(obj#261)'"
+                  "string": "caught panic 'add_member error' from contract function 'Symbol(obj#269)'"
                 },
                 {
                   "u64": 1

--- a/contract/test_snapshots/tests/test_add_member_permission_denied.1.json
+++ b/contract/test_snapshots/tests/test_add_member_permission_denied.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -617,6 +637,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -967,6 +1027,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1536,7 +1616,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'add_member error' from contract function 'Symbol(obj#395)'"
+                  "string": "caught panic 'add_member error' from contract function 'Symbol(obj#403)'"
                 },
                 {
                   "u64": 1

--- a/contract/test_snapshots/tests/test_admin_can_add_members_and_contributors.1.json
+++ b/contract/test_snapshots/tests/test_admin_can_add_members_and_contributors.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -712,6 +732,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -1062,6 +1122,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_admin_cannot_add_owner.1.json
+++ b/contract/test_snapshots/tests/test_admin_cannot_add_owner.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -523,6 +543,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -873,6 +933,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1260,7 +1340,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'add_member error' from contract function 'Symbol(obj#261)'"
+                  "string": "caught panic 'add_member error' from contract function 'Symbol(obj#269)'"
                 },
                 {
                   "u64": 1

--- a/contract/test_snapshots/tests/test_can_demote_owner_if_multiple.1.json
+++ b/contract/test_snapshots/tests/test_can_demote_owner_if_multiple.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 2001
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -583,6 +603,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 2001
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -933,6 +993,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 2001
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_cannot_demote_last_owner.1.json
+++ b/contract/test_snapshots/tests/test_cannot_demote_last_owner.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -523,6 +543,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -873,6 +933,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1260,7 +1340,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'update_role error' from contract function 'Symbol(obj#261)'"
+                  "string": "caught panic 'update_role error' from contract function 'Symbol(obj#269)'"
                 },
                 {
                   "u64": 1

--- a/contract/test_snapshots/tests/test_create_guild_invalid_description_too_long.1.json
+++ b/contract/test_snapshots/tests/test_create_guild_invalid_description_too_long.1.json
@@ -612,6 +612,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -635,7 +655,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'create_guild error' from contract function 'Symbol(obj#89)'"
+                  "string": "caught panic 'create_guild error' from contract function 'Symbol(obj#91)'"
                 },
                 {
                   "string": "Guild"
@@ -645,6 +665,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -713,6 +753,26 @@
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "hash"
+                          },
+                          "val": {
+                            "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "nonce"
+                          },
+                          "val": {
+                            "u64": 9000
+                          }
+                        }
+                      ]
                     }
                   ]
                 }

--- a/contract/test_snapshots/tests/test_create_guild_invalid_name_empty.1.json
+++ b/contract/test_snapshots/tests/test_create_guild_invalid_name_empty.1.json
@@ -612,6 +612,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -635,7 +655,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'create_guild error' from contract function 'Symbol(obj#89)'"
+                  "string": "caught panic 'create_guild error' from contract function 'Symbol(obj#91)'"
                 },
                 {
                   "string": ""
@@ -645,6 +665,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -713,6 +753,26 @@
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "hash"
+                          },
+                          "val": {
+                            "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "nonce"
+                          },
+                          "val": {
+                            "u64": 9000
+                          }
+                        }
+                      ]
                     }
                   ]
                 }

--- a/contract/test_snapshots/tests/test_create_guild_owner_is_member.1.json
+++ b/contract/test_snapshots/tests/test_create_guild_owner_is_member.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -430,6 +450,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -780,6 +840,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_create_guild_success.1.json
+++ b/contract/test_snapshots/tests/test_create_guild_success.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -428,6 +448,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -778,6 +838,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_create_multiple_guilds.1.json
+++ b/contract/test_snapshots/tests/test_create_multiple_guilds.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 1001
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -47,6 +67,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 1002
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -585,6 +625,54 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 1001
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "u64": 1002
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -935,6 +1023,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 1001
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1114,6 +1222,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 1002
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_full_guild_lifecycle.1.json
+++ b/contract/test_snapshots/tests/test_full_guild_lifecycle.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -800,6 +820,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -1150,6 +1210,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_get_all_members.1.json
+++ b/contract/test_snapshots/tests/test_get_all_members.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -712,6 +732,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -1062,6 +1122,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_get_member.1.json
+++ b/contract/test_snapshots/tests/test_get_member.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -523,6 +543,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -873,6 +933,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_get_member_not_found.1.json
+++ b/contract/test_snapshots/tests/test_get_member_not_found.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -523,6 +543,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -873,6 +933,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1254,7 +1334,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'get_member error' from contract function 'Symbol(obj#261)'"
+                  "string": "caught panic 'get_member error' from contract function 'Symbol(obj#269)'"
                 },
                 {
                   "u64": 1

--- a/contract/test_snapshots/tests/test_has_permission.1.json
+++ b/contract/test_snapshots/tests/test_has_permission.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -726,6 +746,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -1076,6 +1136,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_is_member.1.json
+++ b/contract/test_snapshots/tests/test_is_member.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -526,6 +546,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -876,6 +936,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_remove_last_owner_fails.1.json
+++ b/contract/test_snapshots/tests/test_remove_last_owner_fails.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -429,6 +449,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -779,6 +839,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -981,7 +1061,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'remove_member error' from contract function 'Symbol(obj#145)'"
+                  "string": "caught panic 'remove_member error' from contract function 'Symbol(obj#153)'"
                 },
                 {
                   "u64": 1

--- a/contract/test_snapshots/tests/test_remove_member_by_owner.1.json
+++ b/contract/test_snapshots/tests/test_remove_member_by_owner.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -549,6 +569,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -899,6 +959,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_remove_non_owner_by_non_owner_fails.1.json
+++ b/contract/test_snapshots/tests/test_remove_non_owner_by_non_owner_fails.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -617,6 +637,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -967,6 +1027,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1533,7 +1613,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'remove_member error' from contract function 'Symbol(obj#395)'"
+                  "string": "caught panic 'remove_member error' from contract function 'Symbol(obj#403)'"
                 },
                 {
                   "u64": 1

--- a/contract/test_snapshots/tests/test_self_removal.1.json
+++ b/contract/test_snapshots/tests/test_self_removal.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -548,6 +568,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -898,6 +958,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_update_role_by_owner.1.json
+++ b/contract/test_snapshots/tests/test_update_role_by_owner.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -584,6 +604,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -934,6 +994,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/contract/test_snapshots/tests/test_update_role_permission_denied.1.json
+++ b/contract/test_snapshots/tests/test_update_role_permission_denied.1.json
@@ -22,6 +22,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -617,6 +637,46 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
+              "symbol": "pow_used"
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "symbol": "pow_used"
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "u64": 9000
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
               "vec": [
                 {
                   "symbol": "NextPlanId"
@@ -967,6 +1027,26 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "hash"
+                      },
+                      "val": {
+                        "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "nonce"
+                      },
+                      "val": {
+                        "u64": 9000
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1536,7 +1616,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'update_role error' from contract function 'Symbol(obj#395)'"
+                  "string": "caught panic 'update_role error' from contract function 'Symbol(obj#403)'"
                 },
                 {
                   "u64": 1

--- a/contract/test_snapshots/treasury/tests/tests/test_budget_enforcement.1.json
+++ b/contract/test_snapshots/treasury/tests/tests/test_budget_enforcement.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -2233,7 +2234,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/treasury/tests/tests/test_emergency_pause_blocks_new_ops.1.json
+++ b/contract/test_snapshots/treasury/tests/tests/test_emergency_pause_blocks_new_ops.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1512,7 +1513,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/treasury/tests/tests/test_multisig_threshold_not_met.1.json
+++ b/contract/test_snapshots/treasury/tests/tests/test_multisig_threshold_not_met.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1643,7 +1644,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/treasury/tests/tests/test_multisig_timeout_expiration.1.json
+++ b/contract/test_snapshots/treasury/tests/tests/test_multisig_timeout_expiration.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1700,7 +1701,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/treasury/tests/tests/test_multisig_withdrawal_flow.1.json
+++ b/contract/test_snapshots/treasury/tests/tests/test_multisig_withdrawal_flow.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1920,7 +1921,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }

--- a/contract/test_snapshots/treasury/tests/tests/test_treasury_initialize_and_deposit_accounting.1.json
+++ b/contract/test_snapshots/treasury/tests/tests/test_treasury_initialize_and_deposit_accounting.1.json
@@ -22,7 +22,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -1455,7 +1456,8 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
+                },
+                "void"
               ]
             }
           }


### PR DESCRIPTION
## Surmary

Add anti-spam guild initialization (PoW/deposit) and mock MFA flow for admin upgrades, including proof validation, SpamError, and two-step signature execution with timeout handling.

closes #359
closes #363