### PR TITLE
Add bounty category metadata

### DIFF
--- a/contract/src/bounty/mod.rs
+++ b/contract/src/bounty/mod.rs
@@ -39,7 +39,7 @@ use crate::guild::membership::has_permission;
 use crate::guild::types::Role;
 use soroban_sdk::{Address, Env, String, Vec};
 
-pub use types::{Bounty, BountyStatus, PayoutSplit};
+pub use types::{Bounty, BountyCategory, BountyStatus, PayoutSplit};
 
 const TOTAL_BPS: i128 = 10_000;
 
@@ -56,6 +56,31 @@ pub fn create_bounty(
     reward_amount: i128,
     token: Address,
     expiry: u64,
+) -> u64 {
+    create_bounty_with_category(
+        env,
+        guild_id,
+        creator,
+        title,
+        description,
+        reward_amount,
+        token,
+        expiry,
+        BountyCategory::Other,
+    )
+}
+
+/// Create a new bounty with structured category metadata
+pub fn create_bounty_with_category(
+    env: &Env,
+    guild_id: u64,
+    creator: Address,
+    title: String,
+    description: String,
+    reward_amount: i128,
+    token: Address,
+    expiry: u64,
+    category: BountyCategory,
 ) -> u64 {
     creator.require_auth();
 
@@ -91,6 +116,7 @@ pub fn create_bounty(
         creator: creator.clone(),
         title,
         description,
+        category,
         reward_amount,
         funded_amount: 0,
         token: token.clone(),

--- a/contract/src/bounty/tests.rs
+++ b/contract/src/bounty/tests.rs
@@ -6,7 +6,7 @@
 //! NOTE: These tests use the contract client to test through the main lib.rs
 //! contract interface, ensuring proper contract context execution.
 
-use crate::bounty::types::{BountyStatus, PayoutSplit};
+use crate::bounty::types::{BountyCategory, BountyStatus, PayoutSplit};
 use crate::guild::types::Role;
 use crate::InitializerProof;
 use crate::StellarGuildsContract;
@@ -115,9 +115,44 @@ fn test_create_bounty_success() {
     assert_eq!(bounty.creator, owner);
     assert_eq!(bounty.reward_amount, reward_amount);
     assert_eq!(bounty.funded_amount, 0);
+    assert_eq!(bounty.category, BountyCategory::Other);
     assert_eq!(bounty.status, BountyStatus::AwaitingFunds);
     assert_eq!(bounty.expires_at, expiry);
     assert!(bounty.claimer.is_none());
+}
+
+#[test]
+fn test_create_bounty_with_category_stores_category() {
+    let env = setup_env();
+    let owner = Address::generate(&env);
+    let token = create_mock_token(&env, &owner);
+
+    set_ledger_timestamp(&env, 1000);
+    env.mock_all_auths();
+
+    let contract_id = register_and_init_contract(&env);
+    let client = StellarGuildsContractClient::new(&env, &contract_id);
+
+    let guild_id = setup_guild(&client, &env, &owner);
+
+    let title = String::from_str(&env, "Improve docs");
+    let description = String::from_str(&env, "Write onboarding documentation");
+    let reward_amount = 25i128;
+    let expiry = 2000u64;
+
+    let bounty_id = client.create_bounty_with_category(
+        &guild_id,
+        &owner,
+        &title,
+        &description,
+        &reward_amount,
+        &token,
+        &expiry,
+        &BountyCategory::Documentation,
+    );
+
+    let bounty = client.get_bounty(&bounty_id);
+    assert_eq!(bounty.category, BountyCategory::Documentation);
 }
 
 #[test]
@@ -1997,6 +2032,7 @@ fn test_bounty_serialization() {
         creator: Address::generate(&env),
         title: String::from_str(&env, "Title"),
         description: String::from_str(&env, "Desc"),
+        category: BountyCategory::Development,
         reward_amount: 100,
         funded_amount: 50,
         token: Address::generate(&env),
@@ -2012,6 +2048,7 @@ fn test_bounty_serialization() {
 
     assert_eq!(bounty.id, deserialized.id);
     assert_eq!(bounty.status, deserialized.status);
+    assert_eq!(bounty.category, deserialized.category);
     assert_eq!(bounty.reward_amount, deserialized.reward_amount);
 }
 

--- a/contract/src/bounty/types.rs
+++ b/contract/src/bounty/types.rs
@@ -14,6 +14,17 @@ pub enum BountyStatus {
     Funded = 7,
 }
 
+/// Machine-readable category metadata for bounty discovery
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BountyCategory {
+    Development = 0,
+    Design = 1,
+    Documentation = 2,
+    Research = 3,
+    Other = 4,
+}
+
 /// Bounty struct containing all bounty metadata and state
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -28,6 +39,8 @@ pub struct Bounty {
     pub title: String,
     /// Detailed description
     pub description: String,
+    /// Structured category metadata
+    pub category: BountyCategory,
     /// Amount of tokens defined as reward
     pub reward_amount: i128,
     /// Amount of tokens currently funded

--- a/contract/src/interfaces/tests.rs
+++ b/contract/src/interfaces/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::bounty::types::{Bounty, BountyStatus};
+    use crate::bounty::types::{Bounty, BountyCategory, BountyStatus};
     use crate::dispute::types::{Dispute, DisputeReference, DisputeStatus};
     use crate::governance::types::{ExecutionPayload, Proposal, ProposalStatus, ProposalType};
     use crate::guild::types::{Member, Role};
@@ -65,6 +65,7 @@ mod tests {
                 creator: Address::generate(&env),
                 title: String::from_str(&env, "Bounty"),
                 description: String::from_str(&env, "Bounty desc"),
+                category: BountyCategory::Other,
                 reward_amount: 100,
                 funded_amount: 100,
                 token: Address::generate(&env),

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -19,7 +19,7 @@ mod bounty;
 use bounty::{
     approve_bounty, approve_completion, cancel_bounty, claim_bounty, claim_payout, create_bounty,
     expire_bounty, fund_bounty, get_bounty_data, get_guild_bounties_list, release_escrow,
-    submit_work, Bounty, PayoutSplit,
+    submit_work, Bounty, BountyCategory, PayoutSplit,
 };
 
 mod treasury;
@@ -1741,6 +1741,44 @@ impl StellarGuildsContract {
             reward_amount,
             token,
             expiry,
+        )
+    }
+
+    /// Create a new bounty with structured category metadata
+    ///
+    /// # Arguments
+    /// * `guild_id` - The ID of the guild creating the bounty
+    /// * `creator` - Address of the bounty creator (must be guild admin/owner)
+    /// * `title` - Short title for the bounty
+    /// * `description` - Detailed description of the task
+    /// * `reward_amount` - Amount of tokens as reward
+    /// * `token` - Address of the token contract
+    /// * `expiry` - Absolute timestamp when the bounty expires
+    /// * `category` - Machine-readable bounty category metadata
+    ///
+    /// # Returns
+    /// The ID of the newly created bounty
+    pub fn create_bounty_with_category(
+        env: Env,
+        guild_id: u64,
+        creator: Address,
+        title: String,
+        description: String,
+        reward_amount: i128,
+        token: Address,
+        expiry: u64,
+        category: BountyCategory,
+    ) -> u64 {
+        bounty::create_bounty_with_category(
+            &env,
+            guild_id,
+            creator,
+            title,
+            description,
+            reward_amount,
+            token,
+            expiry,
+            category,
         )
     }
 


### PR DESCRIPTION
## Summary
- add a Soroban-serializable `BountyCategory` enum
- store category metadata on `Bounty` records
- keep existing bounty creation defaulting to `Other` and add category-specific creation

Closes #376

## Tests
- Docker `cargo test --verbose` in `contract`: 292 passed, 0 failed
- Docker `cargo fmt --check`: passed
- `git diff --check`: passed