### PR TITLE
Add bounty submission drawer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-slot": "^1.2.4",
         "@stellar/freighter-api": "^6.0.1",
@@ -1498,6 +1499,60 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -7140,17 +7195,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",
     "@stellar/freighter-api": "^6.0.1",

--- a/frontend/src/app/[locale]/bounties/[id]/page.tsx
+++ b/frontend/src/app/[locale]/bounties/[id]/page.tsx
@@ -33,6 +33,7 @@ export default function BountyDetailPage({ params }: PageProps) {
   const bounty = MOCK_BOUNTIES.find((b) => b.id === id) || MOCK_BOUNTIES[0];
 
   const [showApplicationForm, setShowApplicationForm] = useState(false);
+  const [showSubmissionForm, setShowSubmissionForm] = useState(false);
 
   const [viewState, setViewState] = useState<
     "idle" | "claimed" | "submitting" | "completed"
@@ -208,18 +209,11 @@ export default function BountyDetailPage({ params }: PageProps) {
 
                   {viewState === "claimed" && (
                     <button
-                      onClick={() => setViewState("submitting")}
+                      onClick={() => setShowSubmissionForm(true)}
                       className="w-full bg-violet-500 text-black py-5 rounded-2xl font-black uppercase tracking-widest transition-all hover:bg-violet-400"
                     >
                       Upload Submission
                     </button>
-                  )}
-
-                  {viewState === "submitting" && (
-                    <SubmissionForm
-                      onCancel={() => setViewState("claimed")}
-                      onSubmit={handleFinalSubmit} 
-                    />
                   )}
 
                   {viewState === "completed" && (
@@ -262,6 +256,12 @@ export default function BountyDetailPage({ params }: PageProps) {
         bountyId={bounty.id}
         bountyTitle={bounty.title}
       />
+      <SubmissionForm
+        isOpen={showSubmissionForm}
+        onOpenChange={setShowSubmissionForm}
+        bountyTitle={bounty.title}
+        onSubmitted={handleFinalSubmit}
+      />
     </div>
   );
 }
@@ -296,5 +296,4 @@ const SidebarInfo = ({
     {text}
   </div>
 );
-
 

--- a/frontend/src/features/bounties/components/SubmissionForm.tsx
+++ b/frontend/src/features/bounties/components/SubmissionForm.tsx
@@ -1,35 +1,284 @@
 'use client';
-import { X } from 'lucide-react';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import React from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { CheckCircle2, ExternalLink, Link2, Plus, Trash2, X } from 'lucide-react';
+
+type SubmissionFormValues = {
+  githubPrUrl: string;
+  notes: string;
+  links: { url: string }[];
+};
 
 interface SubmissionFormProps {
-  onCancel: () => void;
-  onSubmit: () => void;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  bountyTitle: string;
+  onSubmitted: () => void;
 }
 
-export const SubmissionForm = ({ onCancel, onSubmit }: SubmissionFormProps) => {
+export const SubmissionForm = ({
+  isOpen,
+  onOpenChange,
+  bountyTitle,
+  onSubmitted,
+}: SubmissionFormProps) => {
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<SubmissionFormValues>({
+    defaultValues: {
+      githubPrUrl: '',
+      notes: '',
+      links: [{ url: '' }],
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'links',
+  });
+
+  const [step, setStep] = React.useState<'details' | 'confirm'>('details');
+  const values = watch();
+
+  const closeDrawer = (open: boolean) => {
+    onOpenChange(open);
+    if (!open) {
+      setStep('details');
+    }
+  };
+
+  const submit = (data: SubmissionFormValues) => {
+    console.log('Bounty submission', {
+      ...data,
+      links: data.links.map((link) => link.url).filter(Boolean),
+    });
+    reset();
+    setStep('details');
+    onOpenChange(false);
+    onSubmitted();
+  };
+
   return (
-    <div className="space-y-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
-      <div className="flex justify-between items-center mb-2">
-        <h4 className="text-[10px] font-black uppercase text-violet-500 tracking-widest">Protocol Upload</h4>
-        <button onClick={onCancel} className="text-slate-500 hover:text-white transition-colors">
-          <X size={16} />
-        </button>
-      </div>
-      <input 
-        className="w-full bg-white/5 border border-slate-800/10 rounded-xl p-3 text-xs outline-none focus:border-violet-500/50" 
-        placeholder="Link to GitHub PR / Repository"
-      />
-      <textarea 
-        className="w-full bg-white/5 border border-slate-800/10 rounded-xl p-3 text-xs outline-none focus:border-violet-500/50" 
-        placeholder="Submission notes (optional)..."
-        rows={3}
-      />
-      <button 
-        onClick={onSubmit} 
-        className="w-full py-4 bg-white text-black text-[10px] font-black uppercase tracking-widest rounded-xl hover:bg-violet-400 transition-colors"
-      >
-        Confirm & Encrypt
-      </button>
-    </div>
+    <Dialog.Root open={isOpen} onOpenChange={closeDrawer}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content className="fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col border-l border-slate-800 bg-slate-950 text-white shadow-2xl">
+          <div className="flex items-start justify-between border-b border-slate-800 p-6">
+            <div>
+              <Dialog.Title className="text-xl font-black uppercase tracking-tight">
+                Submit Bounty Work
+              </Dialog.Title>
+              <Dialog.Description className="mt-2 text-sm text-slate-400">
+                {bountyTitle}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close className="rounded-lg p-2 text-slate-500 transition-colors hover:bg-white/5 hover:text-white">
+              <X size={20} />
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit(submit)} className="flex min-h-0 flex-1 flex-col">
+            <div className="flex items-center gap-3 border-b border-slate-800 px-6 py-4 text-xs font-black uppercase tracking-widest">
+              <StepBadge active={step === 'details'} complete={step === 'confirm'}>
+                1
+              </StepBadge>
+              <span className={step === 'details' ? 'text-white' : 'text-slate-500'}>
+                Proof
+              </span>
+              <div className="h-px flex-1 bg-slate-800" />
+              <StepBadge active={step === 'confirm'}>2</StepBadge>
+              <span className={step === 'confirm' ? 'text-white' : 'text-slate-500'}>
+                Confirm
+              </span>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto p-6">
+              {step === 'details' ? (
+                <div className="space-y-6">
+                  <FieldLabel htmlFor="githubPrUrl" label="GitHub PR URL" />
+                  <div>
+                    <div className="relative">
+                      <ExternalLink
+                        size={16}
+                        className="absolute left-4 top-1/2 -translate-y-1/2 text-violet-400"
+                      />
+                      <input
+                        id="githubPrUrl"
+                        className="w-full rounded-xl border border-slate-800 bg-white/5 py-3 pl-11 pr-4 text-sm outline-none transition-colors placeholder:text-slate-600 focus:border-violet-500"
+                        placeholder="https://github.com/org/repo/pull/123"
+                        {...register('githubPrUrl', {
+                          required: 'GitHub PR URL is required.',
+                          pattern: {
+                            value: /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+\/?$/,
+                            message: 'Enter a valid GitHub pull request URL.',
+                          },
+                        })}
+                      />
+                    </div>
+                    {errors.githubPrUrl && (
+                      <p className="mt-2 text-xs text-red-400">
+                        {errors.githubPrUrl.message}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <FieldLabel htmlFor="notes" label="Additional Notes" />
+                    <textarea
+                      id="notes"
+                      rows={5}
+                      className="mt-2 w-full resize-none rounded-xl border border-slate-800 bg-white/5 p-4 text-sm outline-none transition-colors placeholder:text-slate-600 focus:border-violet-500"
+                      placeholder="Summarize what changed, how it was verified, and anything reviewers should know."
+                      {...register('notes')}
+                    />
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <FieldLabel label="External Links" />
+                      <button
+                        type="button"
+                        onClick={() => append({ url: '' })}
+                        className="inline-flex items-center gap-2 rounded-lg border border-violet-500/30 px-3 py-2 text-xs font-bold uppercase tracking-widest text-violet-300 transition-colors hover:bg-violet-500/10"
+                      >
+                        <Plus size={14} />
+                        Add Link
+                      </button>
+                    </div>
+
+                    {fields.map((field, index) => (
+                      <div key={field.id} className="flex gap-2">
+                        <div className="relative flex-1">
+                          <Link2
+                            size={16}
+                            className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-500"
+                          />
+                          <input
+                            className="w-full rounded-xl border border-slate-800 bg-white/5 py-3 pl-11 pr-4 text-sm outline-none transition-colors placeholder:text-slate-600 focus:border-violet-500"
+                            placeholder="Docs, demo, screenshots, or deployment URL"
+                            {...register(`links.${index}.url` as const)}
+                          />
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => remove(index)}
+                          disabled={fields.length === 1}
+                          className="rounded-xl border border-slate-800 px-3 text-slate-500 transition-colors hover:border-red-500/50 hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-40"
+                          aria-label="Remove external link"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-6">
+                  <div className="rounded-2xl border border-violet-500/20 bg-violet-500/10 p-5">
+                    <div className="mb-3 flex items-center gap-2 text-violet-300">
+                      <CheckCircle2 size={18} />
+                      <h3 className="text-sm font-black uppercase tracking-widest">
+                        Review Before Submission
+                      </h3>
+                    </div>
+                    <p className="text-sm leading-6 text-slate-300">
+                      This records your proof for guild review. Confirm only after the PR and
+                      supporting links are final.
+                    </p>
+                  </div>
+
+                  <ReviewRow label="GitHub PR URL" value={values.githubPrUrl} />
+                  <ReviewRow label="Notes" value={values.notes || 'No notes provided.'} />
+                  <ReviewRow
+                    label="External Links"
+                    value={
+                      values.links.map((link) => link.url).filter(Boolean).join('\n') ||
+                      'No external links provided.'
+                    }
+                  />
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between gap-3 border-t border-slate-800 p-6">
+              <button
+                type="button"
+                onClick={() => (step === 'confirm' ? setStep('details') : closeDrawer(false))}
+                className="rounded-xl border border-slate-800 px-5 py-3 text-xs font-black uppercase tracking-widest text-slate-400 transition-colors hover:bg-white/5 hover:text-white"
+              >
+                {step === 'confirm' ? 'Back' : 'Cancel'}
+              </button>
+
+              {step === 'details' ? (
+                <button
+                  type="button"
+                  onClick={handleSubmit(() => setStep('confirm'))}
+                  className="rounded-xl bg-violet-500 px-5 py-3 text-xs font-black uppercase tracking-widest text-black transition-colors hover:bg-violet-400"
+                >
+                  Continue
+                </button>
+              ) : (
+                <button
+                  type="submit"
+                  className="rounded-xl bg-white px-5 py-3 text-xs font-black uppercase tracking-widest text-black transition-colors hover:bg-violet-200"
+                >
+                  Confirm Submission
+                </button>
+              )}
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };
+
+const FieldLabel = ({ htmlFor, label }: { htmlFor?: string; label: string }) => (
+  <label
+    htmlFor={htmlFor}
+    className="text-[10px] font-black uppercase tracking-[0.3em] text-slate-500"
+  >
+    {label}
+  </label>
+);
+
+const StepBadge = ({
+  active,
+  complete,
+  children,
+}: {
+  active: boolean;
+  complete?: boolean;
+  children: React.ReactNode;
+}) => (
+  <span
+    className={[
+      'grid h-7 w-7 place-items-center rounded-full border text-[10px]',
+      active
+        ? 'border-violet-400 bg-violet-500 text-black'
+        : complete
+          ? 'border-violet-500/40 bg-violet-500/10 text-violet-300'
+          : 'border-slate-800 text-slate-500',
+    ].join(' ')}
+  >
+    {children}
+  </span>
+);
+
+const ReviewRow = ({ label, value }: { label: string; value: string }) => (
+  <div className="rounded-2xl border border-slate-800 bg-white/[0.03] p-4">
+    <p className="mb-2 text-[10px] font-black uppercase tracking-[0.3em] text-slate-500">
+      {label}
+    </p>
+    <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-200">
+      {value}
+    </p>
+  </div>
+);


### PR DESCRIPTION
## Summary
- replace the inline bounty submission area with a Radix Dialog side drawer
- add a two-step proof and confirmation flow before final submission
- use react-hook-form useFieldArray for dynamic external proof links
- keep the task isolated by logging the submission payload instead of calling backend/Soroban

## Verification
- npm run lint (passes with existing warnings)
- npx tsc --noEmit
- git diff --check
- npm run build (blocked by Google Fonts DNS fetch in this environment: fonts.googleapis.com ENOTFOUND)

Closes #274