### PR TITLE
Add bounty review window sequence checks

### DIFF
--- a/contract/src/bounty/mod.rs
+++ b/contract/src/bounty/mod.rs
@@ -42,6 +42,7 @@ use soroban_sdk::{Address, Env, String, Vec};
 pub use types::{Bounty, BountyStatus, PayoutSplit};
 
 const TOTAL_BPS: i128 = 10_000;
+pub const REVIEW_WINDOW_SEQUENCE_LIMIT: u32 = 50;
 
 /// Create a new bounty
 ///
@@ -97,6 +98,7 @@ pub fn create_bounty(
         status,
         claimer: None,
         submission_url: None,
+        review_started_ledger_sequence: None,
         created_at,
         expires_at: expiry,
     };
@@ -315,6 +317,7 @@ pub fn submit_work(env: &Env, bounty_id: u64, submission_url: String) -> bool {
 
     bounty.status = BountyStatus::UnderReview;
     bounty.submission_url = Some(submission_url.clone());
+    bounty.review_started_ledger_sequence = Some(env.ledger().sequence());
     store_bounty(env, &bounty);
 
     emit_event(
@@ -376,6 +379,9 @@ pub fn approve_completion(env: &Env, bounty_id: u64, approver: Address) -> bool 
     }
     if bounty.status != BountyStatus::UnderReview {
         panic!("Bounty is not under review");
+    }
+    if is_review_window_over(env, bounty_id) {
+        panic!("Review window has closed");
     }
 
     bounty.status = BountyStatus::Completed;
@@ -581,6 +587,15 @@ pub fn get_bounty_data(env: &Env, bounty_id: u64) -> Bounty {
 
 pub fn get_guild_bounties_list(env: &Env, guild_id: u64) -> Vec<Bounty> {
     get_guild_bounties(env, guild_id)
+}
+
+pub fn is_review_window_over(env: &Env, bounty_id: u64) -> bool {
+    let bounty = get_bounty(env, bounty_id).expect("Bounty not found");
+    let started_at = bounty
+        .review_started_ledger_sequence
+        .expect("Bounty has no submission under review");
+
+    env.ledger().sequence().saturating_sub(started_at) > REVIEW_WINDOW_SEQUENCE_LIMIT
 }
 
 #[allow(dead_code)]

--- a/contract/src/bounty/tests.rs
+++ b/contract/src/bounty/tests.rs
@@ -35,6 +35,19 @@ fn set_ledger_timestamp(env: &Env, timestamp: u64) {
     });
 }
 
+fn set_ledger(env: &Env, timestamp: u64, sequence_number: u32) {
+    env.ledger().set(LedgerInfo {
+        timestamp,
+        protocol_version: 20,
+        sequence_number,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 100,
+        min_persistent_entry_ttl: 100,
+        max_entry_ttl: 1000000,
+    });
+}
+
 fn register_and_init_contract(env: &Env) -> Address {
     let contract_id = env.register_contract(None, StellarGuildsContract);
     let client = StellarGuildsContractClient::new(env, &contract_id);
@@ -684,6 +697,49 @@ fn test_submit_work_success() {
     let bounty = client.get_bounty(&bounty_id);
     assert_eq!(bounty.status, BountyStatus::UnderReview);
     assert_eq!(bounty.submission_url, Some(submission));
+    assert_eq!(bounty.review_started_ledger_sequence, Some(0));
+}
+
+#[test]
+fn test_submit_work_records_review_ledger_sequence() {
+    let env = setup_env();
+    let owner = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let claimer = Address::generate(&env);
+    let token = create_mock_token(&env, &owner);
+
+    set_ledger(&env, 1000, 25);
+    env.mock_all_auths();
+
+    let contract_id = register_and_init_contract(&env);
+    let client = StellarGuildsContractClient::new(&env, &contract_id);
+
+    let guild_id = setup_guild(&client, &env, &owner);
+    mint_tokens(&env, &token, &funder, 1000);
+
+    let title = String::from_str(&env, "Task");
+    let description = String::from_str(&env, "Description");
+    let bounty_id = client.create_bounty(
+        &guild_id,
+        &owner,
+        &title,
+        &description,
+        &100i128,
+        &token,
+        &2000u64,
+    );
+
+    client.fund_bounty(&bounty_id, &funder, &100i128);
+    client.approve_bounty(&bounty_id, &owner, &claimer);
+    client.claim_bounty(&bounty_id, &claimer);
+
+    set_ledger(&env, 1100, 42);
+
+    let submission = String::from_str(&env, "https://github.com/pr/123");
+    client.submit_work(&bounty_id, &submission);
+
+    let bounty = client.get_bounty(&bounty_id);
+    assert_eq!(bounty.review_started_ledger_sequence, Some(42));
 }
 
 #[test]
@@ -838,6 +894,94 @@ fn test_approve_completion_success() {
 
     let bounty = client.get_bounty(&bounty_id);
     assert_eq!(bounty.status, BountyStatus::Completed);
+}
+
+#[test]
+fn test_is_review_window_over_uses_ledger_sequence() {
+    use crate::bounty::REVIEW_WINDOW_SEQUENCE_LIMIT;
+
+    let env = setup_env();
+    let owner = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let claimer = Address::generate(&env);
+    let token = create_mock_token(&env, &owner);
+
+    set_ledger(&env, 1000, 1);
+    env.mock_all_auths();
+
+    let contract_id = register_and_init_contract(&env);
+    let client = StellarGuildsContractClient::new(&env, &contract_id);
+
+    let guild_id = setup_guild(&client, &env, &owner);
+    mint_tokens(&env, &token, &funder, 1000);
+
+    let title = String::from_str(&env, "Task");
+    let description = String::from_str(&env, "Description");
+    let bounty_id = client.create_bounty(
+        &guild_id,
+        &owner,
+        &title,
+        &description,
+        &100i128,
+        &token,
+        &2000u64,
+    );
+
+    client.fund_bounty(&bounty_id, &funder, &100i128);
+    client.approve_bounty(&bounty_id, &owner, &claimer);
+    client.claim_bounty(&bounty_id, &claimer);
+
+    let submission = String::from_str(&env, "https://github.com/pr/123");
+    client.submit_work(&bounty_id, &submission);
+
+    set_ledger(&env, 1100, 1 + REVIEW_WINDOW_SEQUENCE_LIMIT);
+    assert_eq!(client.is_review_window_over(&bounty_id), false);
+
+    set_ledger(&env, 1200, 2 + REVIEW_WINDOW_SEQUENCE_LIMIT);
+    assert_eq!(client.is_review_window_over(&bounty_id), true);
+}
+
+#[test]
+#[should_panic(expected = "Review window has closed")]
+fn test_approve_completion_after_review_window_fails() {
+    use crate::bounty::REVIEW_WINDOW_SEQUENCE_LIMIT;
+
+    let env = setup_env();
+    let owner = Address::generate(&env);
+    let funder = Address::generate(&env);
+    let claimer = Address::generate(&env);
+    let token = create_mock_token(&env, &owner);
+
+    set_ledger(&env, 1000, 1);
+    env.mock_all_auths();
+
+    let contract_id = register_and_init_contract(&env);
+    let client = StellarGuildsContractClient::new(&env, &contract_id);
+
+    let guild_id = setup_guild(&client, &env, &owner);
+    mint_tokens(&env, &token, &funder, 1000);
+
+    let title = String::from_str(&env, "Task");
+    let description = String::from_str(&env, "Description");
+    let bounty_id = client.create_bounty(
+        &guild_id,
+        &owner,
+        &title,
+        &description,
+        &100i128,
+        &token,
+        &2000u64,
+    );
+
+    client.fund_bounty(&bounty_id, &funder, &100i128);
+    client.approve_bounty(&bounty_id, &owner, &claimer);
+    client.claim_bounty(&bounty_id, &claimer);
+
+    let submission = String::from_str(&env, "https://github.com/pr/123");
+    client.submit_work(&bounty_id, &submission);
+
+    set_ledger(&env, 1200, 2 + REVIEW_WINDOW_SEQUENCE_LIMIT);
+    client.approve_completion(&bounty_id, &owner);
 }
 
 #[test]
@@ -2003,6 +2147,7 @@ fn test_bounty_serialization() {
         status: BountyStatus::Open,
         claimer: None,
         submission_url: None,
+        review_started_ledger_sequence: None,
         created_at: 1000,
         expires_at: 2000,
     };

--- a/contract/src/bounty/types.rs
+++ b/contract/src/bounty/types.rs
@@ -40,6 +40,8 @@ pub struct Bounty {
     pub claimer: Option<Address>,
     /// Submission URL when work is submitted
     pub submission_url: Option<String>,
+    /// Ledger sequence when the current submission entered review
+    pub review_started_ledger_sequence: Option<u32>,
     /// Creation timestamp (seconds)
     pub created_at: u64,
     /// Expiration timestamp (seconds)

--- a/contract/src/interfaces/tests.rs
+++ b/contract/src/interfaces/tests.rs
@@ -71,6 +71,7 @@ mod tests {
                 status: BountyStatus::Funded,
                 claimer: None,
                 submission_url: None,
+                review_started_ledger_sequence: None,
                 created_at: 1,
                 expires_at: 2,
             }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -18,8 +18,8 @@ use guild::types::{Member, Role};
 mod bounty;
 use bounty::{
     approve_bounty, approve_completion, cancel_bounty, claim_bounty, claim_payout, create_bounty,
-    expire_bounty, fund_bounty, get_bounty_data, get_guild_bounties_list, release_escrow,
-    submit_work, Bounty, PayoutSplit,
+    expire_bounty, fund_bounty, get_bounty_data, get_guild_bounties_list, is_review_window_over,
+    release_escrow, submit_work, Bounty, PayoutSplit,
 };
 
 mod treasury;
@@ -1804,6 +1804,17 @@ impl StellarGuildsContract {
     /// `true` if approval was successful
     pub fn approve_completion(env: Env, bounty_id: u64, approver: Address) -> bool {
         approve_completion(&env, bounty_id, approver)
+    }
+
+    /// Check whether a submitted bounty's review window has passed.
+    ///
+    /// # Arguments
+    /// * `submission_id` - The bounty ID for the submitted work under review
+    ///
+    /// # Returns
+    /// `true` if the current ledger sequence exceeds the review window
+    pub fn is_review_window_over(env: Env, submission_id: u64) -> bool {
+        is_review_window_over(&env, submission_id)
     }
 
     /// Release escrow funds to the bounty claimer


### PR DESCRIPTION
## Summary
- record the ledger sequence when submitted bounty work enters review
- expose `is_review_window_over(submission_id)` for sequence-based review deadline checks
- prevent admin completion approval after the review window has closed

## Tests
- `cargo test bounty::tests::test_`
- `cargo test`

Closes #360

Disclosure: AI-assisted with Codex; changes were reviewed and verified before submission.
