### PR TITLE
feat(guild): add structured social links endpoint

### DIFF
--- a/backend/prisma/migrations/20260518000000_add_guild_socials/migration.sql
+++ b/backend/prisma/migrations/20260518000000_add_guild_socials/migration.sql
@@ -1,0 +1,2 @@
+-- Add structured social links for guild public profiles.
+ALTER TABLE "guilds" ADD COLUMN "socials" JSONB DEFAULT '{}';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -141,6 +141,7 @@ model Guild {
   bannerCid   String?
   ownerId     String
   settings    Json?
+  socials     Json?     @default("{}")
   memberCount Int       @default(1)
   isActive    Boolean   @default(true)
 

--- a/backend/src/guild/dto/update-guild-socials.dto.spec.ts
+++ b/backend/src/guild/dto/update-guild-socials.dto.spec.ts
@@ -1,0 +1,27 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { UpdateGuildSocialsDto } from './update-guild-socials.dto';
+
+describe('UpdateGuildSocialsDto', () => {
+  it('accepts valid optional social URLs', async () => {
+    const dto = new UpdateGuildSocialsDto();
+    dto.website = 'https://example.org';
+    dto.twitter = 'https://twitter.com/stellarorg';
+    dto.discord = 'https://discord.gg/stellar';
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects malformed social URLs', async () => {
+    const dto = new UpdateGuildSocialsDto();
+    dto.website = 'example.org';
+    dto.twitter = 'not-a-url';
+    dto.discord = 'discord.gg/stellar';
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(3);
+  });
+});

--- a/backend/src/guild/dto/update-guild-socials.dto.ts
+++ b/backend/src/guild/dto/update-guild-socials.dto.ts
@@ -1,0 +1,33 @@
+import { IsOptional, IsUrl } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+const URL_VALIDATION_OPTIONS = {
+  protocols: ['http', 'https'],
+  require_protocol: true,
+};
+
+export class UpdateGuildSocialsDto {
+  @ApiPropertyOptional({
+    description: 'Guild website URL',
+    example: 'https://example.org',
+  })
+  @IsOptional()
+  @IsUrl(URL_VALIDATION_OPTIONS)
+  website?: string;
+
+  @ApiPropertyOptional({
+    description: 'Guild Twitter/X profile URL',
+    example: 'https://twitter.com/stellarorg',
+  })
+  @IsOptional()
+  @IsUrl(URL_VALIDATION_OPTIONS)
+  twitter?: string;
+
+  @ApiPropertyOptional({
+    description: 'Guild Discord invite or community URL',
+    example: 'https://discord.gg/stellar',
+  })
+  @IsOptional()
+  @IsUrl(URL_VALIDATION_OPTIONS)
+  discord?: string;
+}

--- a/backend/src/guild/guild.controller.ts
+++ b/backend/src/guild/guild.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Query,
   Patch,
+  Put,
   Delete,
   UploadedFile,
   UseInterceptors,
@@ -23,6 +24,7 @@ import { GuildService } from './guild.service';
 import { ApplicationService } from './application.service';
 import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
+import { UpdateGuildSocialsDto } from './dto/update-guild-socials.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
 import { ApproveInviteDto } from './dto/approve-invite.dto';
 import { SearchGuildDto } from './dto/search-guild.dto';
@@ -89,6 +91,21 @@ export class GuildController {
     @Request() req: any,
   ) {
     return this.guildService.updateGuild(id, dto, req.user.userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Put(':id/socials')
+  @UseGuards(GuildRoleGuard)
+  @GuildRoles('ADMIN', 'OWNER')
+  @ApiOperation({ summary: 'Update structured guild social links' })
+  @ApiParam({ name: 'id', description: 'Guild ID' })
+  @ApiBody({ type: UpdateGuildSocialsDto })
+  async updateSocials(
+    @Param('id') id: string,
+    @Body() dto: UpdateGuildSocialsDto,
+    @Request() req: any,
+  ) {
+    return this.guildService.updateGuildSocials(id, dto, req.user.userId);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/guild/guild.service.spec.ts
+++ b/backend/src/guild/guild.service.spec.ts
@@ -16,6 +16,7 @@ const mockPrisma = () => ({
   },
   guildMembership: {
     create: jest.fn(),
+    count: jest.fn(),
     findUnique: jest.fn(),
     findFirst: jest.fn(),
     findMany: jest.fn(),
@@ -90,6 +91,31 @@ describe('GuildService (settings integration)', () => {
       'owner1',
     );
     expect(updated.settings.requireApproval).toBe(true);
+  });
+
+  it('updates structured guild socials when caller can manage guild', async () => {
+    const guildId = 'g-1';
+    const socials = {
+      website: 'https://example.org',
+      twitter: 'https://twitter.com/stellarorg',
+      discord: 'https://discord.gg/stellar',
+    };
+    prisma.guild.findUnique.mockResolvedValue({ id: guildId, ownerId: 'owner1' });
+    prisma.guild.update.mockImplementation(({ where, data }: any) =>
+      Promise.resolve({ id: where.id, ...data }),
+    );
+
+    const updated = await service.updateGuildSocials(
+      guildId,
+      socials,
+      'owner1',
+    );
+
+    expect(prisma.guild.update).toHaveBeenCalledWith({
+      where: { id: guildId },
+      data: { socials },
+    });
+    expect(updated.socials).toEqual(socials);
   });
 
   it('searches only discoverable guilds', async () => {

--- a/backend/src/guild/guild.service.ts
+++ b/backend/src/guild/guild.service.ts
@@ -12,6 +12,7 @@ import { MailerService } from '../mailer/mailer.service';
 import { StorageService } from '../storage/storage.service';
 import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
+import { UpdateGuildSocialsDto } from './dto/update-guild-socials.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
 import { UpdateGuildMembershipDto } from './dto/update-guild-membership.dto';
 import { randomUUID } from 'crypto';
@@ -187,6 +188,19 @@ export class GuildService {
     }
 
     return this.prisma.guild.update({ where: { id: guildId }, data });
+  }
+
+  async updateGuildSocials(
+    guildId: string,
+    dto: UpdateGuildSocialsDto,
+    userId: string,
+  ) {
+    await this.ensureManagePermission(guildId, userId);
+
+    return this.prisma.guild.update({
+      where: { id: guildId },
+      data: { socials: dto },
+    });
   }
 
   async deleteGuild(guildId: string, userId: string) {


### PR DESCRIPTION
## Summary
- add a `Guild.socials` JSON field plus a Prisma migration
- add `UpdateGuildSocialsDto` with URL validation for `website`, `twitter`, and `discord`
- add protected `PUT /guilds/:id/socials` support for guild admins/owners
- cover DTO validation and service update behavior with tests

## Validation
- `npm test -- --runInBand src/guild/guild.service.spec.ts src/guild/dto/update-guild-socials.dto.spec.ts`
- `npm run build`

Closes #400
